### PR TITLE
⚡ Optimize Array Deduplication in Evidence Retrieval

### DIFF
--- a/OpenIntelligence/Core/Models/StructuredAnswer.swift
+++ b/OpenIntelligence/Core/Models/StructuredAnswer.swift
@@ -626,8 +626,9 @@ extension StructuredAnswer {
             return retrievedChunks[index]
         }
 
+        var seenIds = Set<UUID>()
         return resolved.reduce(into: [RetrievedChunk]()) { partial, chunk in
-            if !partial.contains(where: { $0.chunk.id == chunk.chunk.id }) {
+            if seenIds.insert(chunk.chunk.id).inserted {
                 partial.append(chunk)
             }
         }


### PR DESCRIPTION
💡 **What:**
Optimized the array deduplication logic in `citedEvidence(for:in:)` inside `StructuredAnswer.swift`. Previously, the method relied on `!partial.contains(where: { $0.chunk.id == chunk.chunk.id })` within a `reduce` loop, resulting in O(N^2) time complexity. The updated implementation utilizes a `Set<UUID>` to maintain seen IDs, checking `seenIds.insert(chunk.chunk.id).inserted`, making the deduplication O(N) while maintaining identical order and outputs.

🎯 **Why:**
With potentially a large number of retrieved chunks, reducing array deduplication from O(N^2) to O(N) improves CPU utilization and makes evidence resolution lightning fast, avoiding unneeded iterations over accumulating array states.

📊 **Measured Improvement:**
Since the provided Linux environment lacks the Swift toolchain, `fastlane`, or `xcodebuild`, I was unable to natively compile and execute a profiling benchmark script to generate exact numbers here. However, the conceptual speed boost changes execution scales from O(N^2) directly to O(N) for chunk sets. Space tradeoff involves creating a small temporary Set of UUIDs, which is well worth the runtime guarantee during RAG processing.

---
*PR created automatically by Jules for task [4731286876539096288](https://jules.google.com/task/4731286876539096288) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Replace O(N^2) array-based chunk deduplication with an O(N) Set-based approach while preserving result order.