### PR TITLE
🧪 Add tests for SemanticChunker.extractEntities

### DIFF
--- a/OpenIntelligence/Services/Document/Chunking/SemanticChunker.swift
+++ b/OpenIntelligence/Services/Document/Chunking/SemanticChunker.swift
@@ -1515,7 +1515,7 @@ class SemanticChunker {
     ///
     /// - Parameter text: The chunk text to extract entities from
     /// - Returns: Array of unique entity strings (deduplicated, sorted by first occurrence)
-    private func extractEntities(_ text: String) -> [String] {
+    internal func extractEntities(_ text: String) -> [String] {
         var entities: [String] = []
         var seen = Set<String>()
 

--- a/OpenIntelligenceEngineTests/Services/Document/Chunking/SemanticChunkerTests.swift
+++ b/OpenIntelligenceEngineTests/Services/Document/Chunking/SemanticChunkerTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import OpenIntelligenceEngine
+
+final class SemanticChunkerTests: XCTestCase {
+
+    func testExtractEntitiesNamedEntities() {
+        let chunker = SemanticChunker()
+        let text = "Tim Cook works at Apple in Cupertino."
+        let entities = chunker.extractEntities(text)
+
+        XCTAssertTrue(entities.contains("Tim Cook"), "Should extract Tim Cook as a personal name")
+        XCTAssertTrue(entities.contains("Apple"), "Should extract Apple as an organization name")
+        XCTAssertTrue(entities.contains("Cupertino"), "Should extract Cupertino as a place name")
+    }
+
+    func testExtractEntitiesTechnicalTerms() {
+        let chunker = SemanticChunker()
+        let text = "We use the SemanticChunker class with Foundation framework."
+        let entities = chunker.extractEntities(text)
+
+        XCTAssertTrue(entities.contains("SemanticChunker"), "Should extract SemanticChunker as a technical term (PascalCase)")
+    }
+
+    func testExtractEntitiesCapitalizedNouns() {
+        let chunker = SemanticChunker()
+        let text = "The Model Architecture ensures robust performance."
+        let entities = chunker.extractEntities(text)
+
+        XCTAssertTrue(entities.contains("Model Architecture"), "Should extract Model Architecture as capitalized domain term")
+    }
+
+    func testExtractEntitiesDeduplication() {
+        let chunker = SemanticChunker()
+        let text = "Apple makes the iPhone. Apple is a large company."
+        let entities = chunker.extractEntities(text)
+
+        let appleCount = entities.filter { $0.lowercased() == "apple" }.count
+        XCTAssertEqual(appleCount, 1, "Should deduplicate entities")
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -86,6 +86,11 @@ let package = Package(
                     "-enable-experimental-feature", "DebugDescriptionMacro"
                 ])
             ]
+        ),
+        .testTarget(
+            name: "OpenIntelligenceEngineTests",
+            dependencies: ["OpenIntelligenceEngine"],
+            path: "OpenIntelligenceEngineTests"
         )
     ],
     swiftLanguageModes: [


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `extractEntities` inside `SemanticChunker.swift` lacked unit tests. The access modifier was changed from `private` to `internal` to make it testable.
📊 **Coverage:** Covered named entities (persons, orgs, places), technical terms (PascalCase), capitalized nouns (domain terms), and deduplication logic.
✨ **Result:** Enhanced test coverage, making refactoring `SemanticChunker` significantly safer.

---
*PR created automatically by Jules for task [14244326559098658520](https://jules.google.com/task/14244326559098658520) started by @Gunnarguy*

## Summary by Sourcery

Add unit tests for SemanticChunker entity extraction and expose the extractEntities helper for testing.

New Features:
- Introduce the OpenIntelligenceEngineTests test target to the Swift package.

Enhancements:
- Relax the access level of SemanticChunker.extractEntities to allow direct testing.

Tests:
- Add SemanticChunkerTests covering named entities, technical terms, capitalized domain terms, and deduplication behavior in extractEntities.