### PR TITLE
🧪 Add tests for OpenIntelligenceEngine library creation

### DIFF
--- a/OpenIntelligenceTests/OpenIntelligenceEngineTests.swift
+++ b/OpenIntelligenceTests/OpenIntelligenceEngineTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import OpenIntelligenceEngine
+
+final class OpenIntelligenceEngineTests: XCTestCase {
+
+    var engine: OpenIntelligenceEngine!
+    var tempURL: URL!
+
+    @MainActor
+    override func setUp() async throws {
+        // Set up temporary base directory for AppSupportPaths
+        tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempURL, withIntermediateDirectories: true)
+
+        let config = OIEngineConfiguration(storageURL: tempURL)
+        self.engine = OpenIntelligenceEngine(configuration: config)
+    }
+
+    @MainActor
+    override func tearDown() async throws {
+        if let tempURL = tempURL {
+            try? FileManager.default.removeItem(at: tempURL)
+        }
+        self.engine = nil
+    }
+
+    @MainActor
+    func testCreateLibrary_success() throws {
+        let libraryName = "TestLibrary123"
+
+        let library = try engine.createLibrary(name: libraryName)
+
+        XCTAssertEqual(library.name, libraryName)
+        XCTAssertNotNil(library.id)
+
+        let libraries = engine.listLibraries()
+        XCTAssertTrue(libraries.contains(where: { $0.id == library.id }))
+    }
+
+    @MainActor
+    func testCreateLibrary_emptyNameThrows() throws {
+        XCTAssertThrowsError(try engine.createLibrary(name: "   ")) { error in
+            if case OpenIntelligenceEngineError.invalidRequest(let message) = error {
+                XCTAssertEqual(message, "Library name must not be empty.")
+            } else {
+                XCTFail("Expected invalidRequest error but got \(error)")
+            }
+        }
+    }
+
+    @MainActor
+    func testCreateLibrary_duplicateNameReturnsExisting() throws {
+        let libraryName = "DuplicateTest"
+
+        let library1 = try engine.createLibrary(name: libraryName)
+        let library2 = try engine.createLibrary(name: libraryName)
+
+        XCTAssertEqual(library1.id, library2.id)
+
+        let libraries = engine.listLibraries()
+        let matchingLibraries = libraries.filter { $0.name == libraryName }
+        XCTAssertEqual(matchingLibraries.count, 1, "There should be only one library with this name")
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "OpenIntelligenceEngine",
     platforms: [
-        .iOS("26.0")
+        .iOS("26.0"),
+        .macOS("15.0")
     ],
     products: [
         .library(
@@ -86,6 +87,11 @@ let package = Package(
                     "-enable-experimental-feature", "DebugDescriptionMacro"
                 ])
             ]
+        ),
+        .testTarget(
+            name: "OpenIntelligenceEngineTests",
+            dependencies: ["OpenIntelligenceEngine"],
+            path: "OpenIntelligenceTests"
         )
     ],
     swiftLanguageModes: [


### PR DESCRIPTION
🎯 **What:** Added comprehensive test coverage for the `createLibrary(name:)` core SDK entry point in `OpenIntelligenceEngine.swift`.
📊 **Coverage:** Now tests the happy path creation, validation of empty inputs (throwing invalidRequest), and handling of duplicate names returning the existing instance without duplication.
✨ **Result:** Improved reliability and safe refactoring guarantees for the core entry point of the SDK.

---
*PR created automatically by Jules for task [9774002339920459115](https://jules.google.com/task/9774002339920459115) started by @Gunnarguy*

## Summary by Sourcery

Add macOS platform support and introduce tests for the OpenIntelligenceEngine createLibrary API.

Enhancements:
- Declare macOS 15.0 as a supported platform for the OpenIntelligenceEngine package.

Build:
- Add a dedicated OpenIntelligenceEngineTests test target wired to the main library target.

Tests:
- Add unit tests covering successful library creation, validation of empty names, and duplicate-name handling for OpenIntelligenceEngine.createLibrary(name:).