### PR TITLE
🧪 [testing improvement] Add tests for SemanticChunker empty string handling

### DIFF
--- a/OpenIntelligence/Services/Document/Chunking/SemanticChunker.swift
+++ b/OpenIntelligence/Services/Document/Chunking/SemanticChunker.swift
@@ -297,6 +297,11 @@ class SemanticChunker {
         Log.debug("[SemanticChunker] Target: \(config.targetSize)w, Min: \(config.minSize)w, Max: \(config.maxSize)w", category: .ingestion)
         Log.debug("[SemanticChunker] Overlap: \(config.overlap)w", category: .ingestion)
 
+        // Handle completely empty text early
+        if text.isEmpty {
+            return []
+        }
+
         // Safety check: if text is too small, just return one chunk
         let wordCount = tokenWordCount(text)
         if wordCount < config.minSize {
@@ -566,6 +571,11 @@ class SemanticChunker {
         pageNumbers: [Int: Range<String.Index>]? = nil,
         documentCategory: DocumentSemanticCategory? = nil
     ) async -> [EnhancedChunk] {
+        // Handle completely empty text early
+        if text.isEmpty {
+            return []
+        }
+
         Log.debug("[SemanticChunker] Starting async chunking with embedding boundaries", category: .ingestion)
 
         // Detect embedding-based boundaries if service available

--- a/Package.swift
+++ b/Package.swift
@@ -86,6 +86,10 @@ let package = Package(
                     "-enable-experimental-feature", "DebugDescriptionMacro"
                 ])
             ]
+        ),
+        .testTarget(
+            name: "OpenIntelligenceEngineTests",
+            dependencies: ["OpenIntelligenceEngine"]
         )
     ],
     swiftLanguageModes: [

--- a/Tests/OpenIntelligenceEngineTests/SemanticChunkerTests.swift
+++ b/Tests/OpenIntelligenceEngineTests/SemanticChunkerTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import OpenIntelligenceEngine
+
+final class SemanticChunkerTests: XCTestCase {
+    var chunker: SemanticChunker!
+
+    override func setUp() {
+        super.setUp()
+        chunker = SemanticChunker()
+    }
+
+    override func tearDown() {
+        chunker = nil
+        super.tearDown()
+    }
+
+    func testChunkText_WithEmptyString_ReturnsEmptyArray() {
+        // Arrange
+        let text = ""
+        let documentId = UUID()
+        let config = SemanticChunker.ChunkingConfig(
+            targetSize: 200,
+            minSize: 50,
+            maxSize: 400,
+            overlap: 20,
+            useTopicDetection: true,
+            useSemanticBoundaries: true
+        )
+
+        // Act
+        let chunks = chunker.chunkText(
+            text,
+            documentId: documentId,
+            config: config
+        )
+
+        // Assert
+        XCTAssertTrue(chunks.isEmpty, "Chunking an empty string should return an empty array of chunks.")
+    }
+
+    func testChunkTextAsync_WithEmptyString_ReturnsEmptyArray() async {
+        // Arrange
+        let text = ""
+        let documentId = UUID()
+        let config = SemanticChunker.ChunkingConfig(
+            targetSize: 200,
+            minSize: 50,
+            maxSize: 400,
+            overlap: 20,
+            useTopicDetection: true,
+            useSemanticBoundaries: true
+        )
+
+        // Act
+        let chunks = await chunker.chunkTextAsync(
+            text,
+            documentId: documentId,
+            config: config
+        )
+
+        // Assert
+        XCTAssertTrue(chunks.isEmpty, "Async chunking an empty string should return an empty array of chunks.")
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test and explicit handling for completely empty text strings when generating semantic document chunks.
📊 **Coverage:** What scenarios are now tested: Empty string edge cases for both synchronous (chunkText) and asynchronous (chunkTextAsync) processing paths in SemanticChunker. Added a new OpenIntelligenceEngineTests target to Package.swift.
✨ **Result:** The improvement in test coverage: We now explicitly guarantee that empty document processing does not fail or produce erroneous placeholder chunks.

---
*PR created automatically by Jules for task [17448923822514264813](https://jules.google.com/task/17448923822514264813) started by @Gunnarguy*

## Summary by Sourcery

Handle empty-string input in SemanticChunker and add regression tests for synchronous and asynchronous chunking paths.

Bug Fixes:
- Prevent SemanticChunker from producing chunks when given an entirely empty input string.

Build:
- Add the OpenIntelligenceEngineTests test target to the Swift package manifest.

Tests:
- Add unit tests verifying that chunkText and chunkTextAsync return empty arrays when called with an empty string input.