### PR TITLE
🧪 Add tests for LLM repetition detection

### DIFF
--- a/OpenIntelligence/Services/LLM/LLMService.swift
+++ b/OpenIntelligence/Services/LLM/LLMService.swift
@@ -1062,7 +1062,7 @@ struct LLMResponse {
         }
 
         /// Checks if new text is substantially repeating content from existing text
-        private func isRepetitiveContent(newText: String, existingText: String) -> Bool {
+        internal func isRepetitiveContent(newText: String, existingText: String) -> Bool {
             let newLower = newText.lowercased()
             let existingLower = existingText.lowercased()
 

--- a/OpenIntelligence/Services/LLM/Tests/LLMRepetitionTests.swift
+++ b/OpenIntelligence/Services/LLM/Tests/LLMRepetitionTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import OpenIntelligenceEngine
+
+final class LLMRepetitionTests: XCTestCase {
+
+    // Using a mock class that inherits from LLMService or directly testing the extension if possible.
+    // Let's create an instance of AppleFoundationLLMService if available, otherwise AppleChatGPTExtensionService.
+
+    var service: AppleFoundationLLMService!
+
+    override func setUp() {
+        super.setUp()
+        if #available(iOS 26.0, *) {
+            service = AppleFoundationLLMService()
+        }
+    }
+
+    override func tearDown() {
+        service = nil
+        super.tearDown()
+    }
+
+    func testNonRepetitiveContent() {
+        guard #available(iOS 26.0, *) else { return }
+
+        let existingText = "The capital of France is Paris. It is a very beautiful city."
+        let newText = "The population is over 2 million people and it has many famous landmarks."
+
+        XCTAssertFalse(service.isRepetitiveContent(newText: newText, existingText: existingText))
+    }
+
+    func testRepetitiveContent() {
+        guard #available(iOS 26.0, *) else { return }
+
+        let existingText = "The capital of France is Paris. It is a very beautiful city. The weather is nice today."
+        let newText = "The capital of France is Paris. It is a very beautiful city."
+
+        XCTAssertTrue(service.isRepetitiveContent(newText: newText, existingText: existingText))
+    }
+
+    func testShortContent() {
+        guard #available(iOS 26.0, *) else { return }
+
+        // String with fewer than 30 characters
+        let existingText = "The capital of France is Paris. It is a very beautiful city."
+        let newText = "Paris is great."
+
+        XCTAssertFalse(service.isRepetitiveContent(newText: newText, existingText: existingText))
+    }
+
+    func testCaseInsensitiveRepetition() {
+        guard #available(iOS 26.0, *) else { return }
+
+        let existingText = "The capital of France is Paris. It is a very beautiful city. The weather is nice today."
+        let newText = "tHE CaPiTaL oF fRaNcE iS pArIs. iT iS a VeRy bEaUtiFuL cItY."
+
+        XCTAssertTrue(service.isRepetitiveContent(newText: newText, existingText: existingText))
+    }
+
+    func testPartialRepetition() {
+        guard #available(iOS 26.0, *) else { return }
+
+        let existingText = "The capital of France is Paris. It is known for the Eiffel Tower and the Louvre Museum."
+        // First part is repeated, second part is new.
+        // Let's make sure >50% is overlapping windows.
+        // "The capital of France is Paris. " is about 32 chars.
+        // "It has great food and wine." is about 27 chars.
+        // Total new text is 59 chars.
+        let newText = "The capital of France is Paris. It has great food and wine."
+
+        XCTAssertTrue(service.isRepetitiveContent(newText: newText, existingText: existingText))
+    }
+}

--- a/OpenIntelligence/Services/LLM/Tests/LLMRepetitionTests.swift
+++ b/OpenIntelligence/Services/LLM/Tests/LLMRepetitionTests.swift
@@ -1,7 +1,8 @@
 import XCTest
-@testable import OpenIntelligenceEngine
 
 #if canImport(FoundationModels)
+@testable import OpenIntelligenceEngine
+
 final class LLMRepetitionTests: XCTestCase {
 
     var service: AppleFoundationLLMService!

--- a/OpenIntelligence/Services/LLM/Tests/LLMRepetitionTests.swift
+++ b/OpenIntelligence/Services/LLM/Tests/LLMRepetitionTests.swift
@@ -3,9 +3,12 @@ import XCTest
 
 final class LLMRepetitionTests: XCTestCase {
 
-    // Using a mock class that inherits from LLMService or directly testing the extension if possible.
-    // Let's create an instance of AppleFoundationLLMService if available, otherwise AppleChatGPTExtensionService.
+    // We test the method on `AppleFoundationLLMServiceUnavailable` if iOS 26 isn't available
+    // BUT `AppleFoundationLLMServiceUnavailable` DOES NOT have `isRepetitiveContent` since it's a stub class.
+    // Wait... `isRepetitiveContent` is ONLY defined on `AppleFoundationLLMService` which is wrapped in `#if canImport(FoundationModels)` AND `@available(iOS 26.0, *)`
+    // Therefore, if `FoundationModels` cannot be imported, we shouldn't even test it.
 
+    #if canImport(FoundationModels)
     var service: AppleFoundationLLMService!
 
     override func setUp() {
@@ -19,26 +22,32 @@ final class LLMRepetitionTests: XCTestCase {
         service = nil
         super.tearDown()
     }
+    #endif
 
     func testNonRepetitiveContent() {
+        #if canImport(FoundationModels)
         guard #available(iOS 26.0, *) else { return }
 
         let existingText = "The capital of France is Paris. It is a very beautiful city."
         let newText = "The population is over 2 million people and it has many famous landmarks."
 
         XCTAssertFalse(service.isRepetitiveContent(newText: newText, existingText: existingText))
+        #endif
     }
 
     func testRepetitiveContent() {
+        #if canImport(FoundationModels)
         guard #available(iOS 26.0, *) else { return }
 
         let existingText = "The capital of France is Paris. It is a very beautiful city. The weather is nice today."
         let newText = "The capital of France is Paris. It is a very beautiful city."
 
         XCTAssertTrue(service.isRepetitiveContent(newText: newText, existingText: existingText))
+        #endif
     }
 
     func testShortContent() {
+        #if canImport(FoundationModels)
         guard #available(iOS 26.0, *) else { return }
 
         // String with fewer than 30 characters
@@ -46,18 +55,22 @@ final class LLMRepetitionTests: XCTestCase {
         let newText = "Paris is great."
 
         XCTAssertFalse(service.isRepetitiveContent(newText: newText, existingText: existingText))
+        #endif
     }
 
     func testCaseInsensitiveRepetition() {
+        #if canImport(FoundationModels)
         guard #available(iOS 26.0, *) else { return }
 
         let existingText = "The capital of France is Paris. It is a very beautiful city. The weather is nice today."
         let newText = "tHE CaPiTaL oF fRaNcE iS pArIs. iT iS a VeRy bEaUtiFuL cItY."
 
         XCTAssertTrue(service.isRepetitiveContent(newText: newText, existingText: existingText))
+        #endif
     }
 
     func testPartialRepetition() {
+        #if canImport(FoundationModels)
         guard #available(iOS 26.0, *) else { return }
 
         let existingText = "The capital of France is Paris. It is known for the Eiffel Tower and the Louvre Museum."
@@ -69,5 +82,6 @@ final class LLMRepetitionTests: XCTestCase {
         let newText = "The capital of France is Paris. It has great food and wine."
 
         XCTAssertTrue(service.isRepetitiveContent(newText: newText, existingText: existingText))
+        #endif
     }
 }

--- a/OpenIntelligence/Services/LLM/Tests/LLMRepetitionTests.swift
+++ b/OpenIntelligence/Services/LLM/Tests/LLMRepetitionTests.swift
@@ -1,14 +1,9 @@
 import XCTest
 @testable import OpenIntelligenceEngine
 
+#if canImport(FoundationModels)
 final class LLMRepetitionTests: XCTestCase {
 
-    // We test the method on `AppleFoundationLLMServiceUnavailable` if iOS 26 isn't available
-    // BUT `AppleFoundationLLMServiceUnavailable` DOES NOT have `isRepetitiveContent` since it's a stub class.
-    // Wait... `isRepetitiveContent` is ONLY defined on `AppleFoundationLLMService` which is wrapped in `#if canImport(FoundationModels)` AND `@available(iOS 26.0, *)`
-    // Therefore, if `FoundationModels` cannot be imported, we shouldn't even test it.
-
-    #if canImport(FoundationModels)
     var service: AppleFoundationLLMService!
 
     override func setUp() {
@@ -22,32 +17,26 @@ final class LLMRepetitionTests: XCTestCase {
         service = nil
         super.tearDown()
     }
-    #endif
 
     func testNonRepetitiveContent() {
-        #if canImport(FoundationModels)
         guard #available(iOS 26.0, *) else { return }
 
         let existingText = "The capital of France is Paris. It is a very beautiful city."
         let newText = "The population is over 2 million people and it has many famous landmarks."
 
         XCTAssertFalse(service.isRepetitiveContent(newText: newText, existingText: existingText))
-        #endif
     }
 
     func testRepetitiveContent() {
-        #if canImport(FoundationModels)
         guard #available(iOS 26.0, *) else { return }
 
         let existingText = "The capital of France is Paris. It is a very beautiful city. The weather is nice today."
         let newText = "The capital of France is Paris. It is a very beautiful city."
 
         XCTAssertTrue(service.isRepetitiveContent(newText: newText, existingText: existingText))
-        #endif
     }
 
     func testShortContent() {
-        #if canImport(FoundationModels)
         guard #available(iOS 26.0, *) else { return }
 
         // String with fewer than 30 characters
@@ -55,22 +44,18 @@ final class LLMRepetitionTests: XCTestCase {
         let newText = "Paris is great."
 
         XCTAssertFalse(service.isRepetitiveContent(newText: newText, existingText: existingText))
-        #endif
     }
 
     func testCaseInsensitiveRepetition() {
-        #if canImport(FoundationModels)
         guard #available(iOS 26.0, *) else { return }
 
         let existingText = "The capital of France is Paris. It is a very beautiful city. The weather is nice today."
         let newText = "tHE CaPiTaL oF fRaNcE iS pArIs. iT iS a VeRy bEaUtiFuL cItY."
 
         XCTAssertTrue(service.isRepetitiveContent(newText: newText, existingText: existingText))
-        #endif
     }
 
     func testPartialRepetition() {
-        #if canImport(FoundationModels)
         guard #available(iOS 26.0, *) else { return }
 
         let existingText = "The capital of France is Paris. It is known for the Eiffel Tower and the Louvre Museum."
@@ -82,6 +67,6 @@ final class LLMRepetitionTests: XCTestCase {
         let newText = "The capital of France is Paris. It has great food and wine."
 
         XCTAssertTrue(service.isRepetitiveContent(newText: newText, existingText: existingText))
-        #endif
     }
 }
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
             ],
             path: "OpenIntelligence",
             exclude: [
+                "Services/LLM/Tests",
                 "App",
                 "Features",
                 "OpenIntelligence.entitlements",
@@ -86,6 +87,11 @@ let package = Package(
                     "-enable-experimental-feature", "DebugDescriptionMacro"
                 ])
             ]
+        ),
+        .testTarget(
+            name: "OpenIntelligenceEngineTests",
+            dependencies: ["OpenIntelligenceEngine"],
+            path: "OpenIntelligence/Services/LLM/Tests"
         )
     ],
     swiftLanguageModes: [

--- a/submission.py
+++ b/submission.py
@@ -1,0 +1,1 @@
+print('I am submitting now!')

--- a/submission.py
+++ b/submission.py
@@ -1,1 +1,0 @@
-print('I am submitting now!')


### PR DESCRIPTION
🎯 **What:** Tests were added for the `isRepetitiveContent` function in `LLMService.swift`, which previously lacked coverage.
📊 **Coverage:** The new tests cover non-repetitive text, fully repetitive text, short text edge cases, case-insensitivity, and partial repetition scenarios.
✨ **Result:** Test coverage and code reliability are improved, enabling safe refactoring of LLM output handling. The `isRepetitiveContent` access level was broadened to `internal` to allow testing without exposing the API publicly.

---
*PR created automatically by Jules for task [3127574320089618040](https://jules.google.com/task/3127574320089618040) started by @Gunnarguy*

## Summary by Sourcery

Add unit tests for LLM repetition detection and expose the helper for internal testing.

Enhancements:
- Broaden the access level of the LLM repetition detection helper to internal to allow test coverage without making it public API.

Tests:
- Add an OpenIntelligenceEngineTests test target and LLMRepetitionTests to cover non‑repetitive, fully repetitive, short, case-insensitive, and partially repetitive content scenarios.

Chores:
- Add a submission helper script and update the package manifest to wire up the new test target and exclude its sources from the main target.