### PR TITLE
🧪 Add unit tests for WorkspaceTier ranking logic

### DIFF
--- a/OpenIntelligenceTests/Core/Models/WorkspaceTierTests.swift
+++ b/OpenIntelligenceTests/Core/Models/WorkspaceTierTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import OpenIntelligenceEngine
+
+final class WorkspaceTierTests: XCTestCase {
+
+    func testRank() {
+        XCTAssertEqual(WorkspaceTier.free.rank, 0)
+        XCTAssertEqual(WorkspaceTier.pro.rank, 1)
+        XCTAssertEqual(WorkspaceTier.lifetime.rank, 2)
+    }
+
+    func testIsAtLeast() {
+        // Free tier checks
+        XCTAssertTrue(WorkspaceTier.free.isAtLeast(.free))
+        XCTAssertFalse(WorkspaceTier.free.isAtLeast(.pro))
+        XCTAssertFalse(WorkspaceTier.free.isAtLeast(.lifetime))
+
+        // Pro tier checks
+        XCTAssertTrue(WorkspaceTier.pro.isAtLeast(.free))
+        XCTAssertTrue(WorkspaceTier.pro.isAtLeast(.pro))
+        XCTAssertFalse(WorkspaceTier.pro.isAtLeast(.lifetime))
+
+        // Lifetime tier checks
+        XCTAssertTrue(WorkspaceTier.lifetime.isAtLeast(.free))
+        XCTAssertTrue(WorkspaceTier.lifetime.isAtLeast(.pro))
+        XCTAssertTrue(WorkspaceTier.lifetime.isAtLeast(.lifetime))
+    }
+
+    func testDisplayName() {
+        XCTAssertEqual(WorkspaceTier.free.displayName, "Free")
+        XCTAssertEqual(WorkspaceTier.pro.displayName, "Pro")
+        XCTAssertEqual(WorkspaceTier.lifetime.displayName, "Lifetime")
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added a new test file `WorkspaceTierTests.swift` to test the pure logic of the `WorkspaceTier` enum.
📊 **Coverage:** Added full test coverage for the `rank` property and the `isAtLeast` comparison helper function across all `.free`, `.pro`, and `.lifetime` cases.
✨ **Result:** Ensured robust comparisons in tier-gating and prevented accidental regressions to authorization logic.

---
*PR created automatically by Jules for task [3679059478034249032](https://jules.google.com/task/3679059478034249032) started by @Gunnarguy*

## Summary by Sourcery

Add unit tests covering WorkspaceTier ranking and comparison behavior.

Tests:
- Add unit tests for WorkspaceTier.rank values across free, pro, and lifetime tiers.
- Add unit tests for WorkspaceTier.isAtLeast helper to verify tier comparison ordering.
- Add unit tests for WorkspaceTier.displayName formatting for all tiers.