### PR TITLE
🔒 Fix potential SQL Injection in SQLite schema modification

### DIFF
--- a/OpenIntelligence/Services/Storage/SQLiteFullTextService.swift
+++ b/OpenIntelligence/Services/Storage/SQLiteFullTextService.swift
@@ -3058,6 +3058,17 @@ actor SQLiteFullTextService {
     private func ensureColumnExists(table: String, column: String, definition: String) {
         guard let db = database else { return }
 
+        // Security fix: Validate table and column names to prevent SQL injection
+        let validIdentifierRegex = "^[a-zA-Z_][a-zA-Z0-9_]*$"
+        guard table.range(of: validIdentifierRegex, options: .regularExpression) != nil else {
+            Log.error("[SQLiteFTS5] Invalid table name for schema modification: \(table)", category: .vectorDB)
+            return
+        }
+        guard column.range(of: validIdentifierRegex, options: .regularExpression) != nil else {
+            Log.error("[SQLiteFTS5] Invalid column name for schema modification: \(column)", category: .vectorDB)
+            return
+        }
+
         let pragmaSQL = "PRAGMA table_info(\(table))"
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, pragmaSQL, -1, &statement, nil) == SQLITE_OK else { return }


### PR DESCRIPTION
🎯 **What:** Fixed a potential SQL injection vulnerability in `ensureColumnExists` within `SQLiteFullTextService.swift` where table and column names were unsafely interpolated into SQL strings.

⚠️ **Risk:** Although currently called with hardcoded values, the function's signature allowed strings to be passed and interpolated directly into `PRAGMA table_info(...)` and `ALTER TABLE ... ADD COLUMN ...` queries. If used dynamically in the future, it could allow an attacker to inject arbitrary SQL statements or alter schema in unintended ways.

🛡️ **Solution:** Implemented early validation of the `table` and `column` parameters against a strict regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`. This ensures that only valid SQL identifiers can be passed. If validation fails, an error is logged and the function returns early, preventing the query from being executed.

(Note: Tests could not be run directly due to the lack of Swift toolchain in the environment, but the changes were carefully reviewed manually and follow standard Swift regex validation patterns and logging practices.)

---
*PR created automatically by Jules for task [5969573126713650346](https://jules.google.com/task/5969573126713650346) started by @Gunnarguy*

## Summary by Sourcery

Bug Fixes:
- Harden SQLite schema modification by rejecting invalid table and column identifiers before constructing PRAGMA and ALTER TABLE queries.