### PR TITLE
⚡ Optimize vector magnitude calculation in NLEmbeddingProvider

### DIFF
--- a/OpenIntelligence/Services/Embedding/Providers/NLEmbeddingProvider.swift
+++ b/OpenIntelligence/Services/Embedding/Providers/NLEmbeddingProvider.swift
@@ -189,7 +189,7 @@ final class NLEmbeddingProvider: EmbeddingProvider {
             let hasNumbers = normalized.rangeOfCharacter(from: .decimalDigits) != nil
             vec[266] = hasNumbers ? 1.0 : -1.0
         }
-        let magnitude = sqrt(vec.map { $0 * $0 }.reduce(0, +))
+        let magnitude = sqrt(vec.reduce(0) { $0 + $1 * $1 })
         if magnitude > 0 {
             vec = vec.map { $0 / magnitude }
         }


### PR DESCRIPTION
💡 **What:** 
Replaced `vec.map { $0 * $0 }.reduce(0, +)` with `vec.reduce(0) { $0 + $1 * $1 }` in `NLEmbeddingProvider.swift:192`.

🎯 **Why:** 
The previous implementation used `map` which created an intermediate array for the squared values before reducing them. This caused unnecessary memory allocation and an extra pass over the data. The updated approach calculates the sum of squares directly within `reduce`, yielding the same mathematical result in a single pass with O(1) extra memory.

📊 **Measured Improvement:** 
Due to environment constraints (local compilation and Swift toolchains are unavailable on this Linux runner), formal benchmarking using `scripts/run_rag_benchmarks.py` was skipped. However, eliminating an unnecessary O(N) array allocation on a hot code path (embedding generation) provides a guaranteed theoretical performance improvement in CPU cycles and memory pressure.

---
*PR created automatically by Jules for task [3805029530742572975](https://jules.google.com/task/3805029530742572975) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Streamline magnitude calculation for embedding vectors by removing the intermediate squared-values array to reduce memory usage and passes over the data.