### PR TITLE
🧪 Add tests for StructuredAnswer.citationIndex extraction

### DIFF
--- a/OpenIntelligence/Core/Models/StructuredAnswer.swift
+++ b/OpenIntelligence/Core/Models/StructuredAnswer.swift
@@ -677,7 +677,7 @@ extension StructuredAnswer {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    nonisolated private static func citationIndex(from citation: String) -> Int? {
+    nonisolated internal static func citationIndex(from citation: String) -> Int? {
         let pattern = #"S(\d+)"#
         guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
             return nil

--- a/OpenIntelligenceTests/Core/Models/StructuredAnswerTests.swift
+++ b/OpenIntelligenceTests/Core/Models/StructuredAnswerTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import OpenIntelligence
+
+final class StructuredAnswerTests: XCTestCase {
+
+    // MARK: - citationIndex Tests
+
+    func testCitationIndex_validFormats() {
+        XCTAssertEqual(StructuredAnswer.citationIndex(from: "S1"), 0)
+        XCTAssertEqual(StructuredAnswer.citationIndex(from: "s2"), 1)
+        XCTAssertEqual(StructuredAnswer.citationIndex(from: "[S3]"), 2)
+        XCTAssertEqual(StructuredAnswer.citationIndex(from: " [s4] "), 3)
+        XCTAssertEqual(StructuredAnswer.citationIndex(from: "S10"), 9)
+        XCTAssertEqual(StructuredAnswer.citationIndex(from: "S999"), 998)
+    }
+
+    func testCitationIndex_invalidFormats() {
+        XCTAssertNil(StructuredAnswer.citationIndex(from: ""))
+        XCTAssertNil(StructuredAnswer.citationIndex(from: "S"))
+        XCTAssertNil(StructuredAnswer.citationIndex(from: "1"))
+        XCTAssertNil(StructuredAnswer.citationIndex(from: "S0")) // Must be > 0
+        XCTAssertNil(StructuredAnswer.citationIndex(from: "S-1"))
+        XCTAssertNil(StructuredAnswer.citationIndex(from: "abc"))
+        XCTAssertNil(StructuredAnswer.citationIndex(from: "Sabc"))
+    }
+
+    func testCitationIndex_withExtraText() {
+        // According to current implementation, firstMatch is used, so it might extract from middle of string
+        XCTAssertEqual(StructuredAnswer.citationIndex(from: "Source S5"), 4)
+        XCTAssertEqual(StructuredAnswer.citationIndex(from: "S6 is the source"), 5)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the `citationIndex(from:)` parsing logic inside `StructuredAnswer.swift`. This covers the previous testing gap for this utility function.
📊 **Coverage:** Covered valid scenarios (like "S1", "s2", "[S3]"), invalid scenarios (empty strings, "S", "S0"), and handling text containing multiple elements. Modified visibility of `citationIndex` from `private` to `internal` so it can be accessed via `@testable import`.
✨ **Result:** Enhanced test coverage ensures the stability and reliability of inline citation extraction when formatting StructuredAnswers.

---
*PR created automatically by Jules for task [14510794647580699205](https://jules.google.com/task/14510794647580699205) started by @Gunnarguy*

## Summary by Sourcery

Add unit test coverage for StructuredAnswer inline citation index parsing and expose the helper for testing.

Enhancements:
- Relax the visibility of StructuredAnswer.citationIndex(from:) from private to internal to allow direct testing.

Tests:
- Add StructuredAnswerTests covering valid, invalid, and mixed-text inputs for citationIndex(from:).