### PR TITLE
🧪 [Add missing tests for RetrievalConfig isCloseTo comparison method]

### DIFF
--- a/OpenIntelligence/Features/Diagnostics/Validation/CoreValidationView.swift
+++ b/OpenIntelligence/Features/Diagnostics/Validation/CoreValidationView.swift
@@ -343,6 +343,39 @@ struct CoreValidationView: View {
                 }
             }
 
+
+            // Test 9: RetrievalConfig - Exact Match
+            await runTest(name: "RetrievalConfig - Exact Match") {
+                let config = RetrievalConfig.default
+                return config.isCloseTo(.default)
+            }
+
+            // Test 10: RetrievalConfig - Within Tolerance
+            await runTest(name: "RetrievalConfig - Within Tolerance") {
+                var config = RetrievalConfig.default
+                // Default tolerance is 0.08
+                config.minSimilarity += 0.05
+                config.vectorWeight -= 0.05
+                config.mmrLambda += 0.05
+                return config.isCloseTo(.default)
+            }
+
+            // Test 11: RetrievalConfig - Outside Tolerance
+            await runTest(name: "RetrievalConfig - Outside Tolerance") {
+                var config = RetrievalConfig.default
+                // Default tolerance is 0.08, modifying by 0.10 should fail
+                config.minSimilarity += 0.10
+                return !config.isCloseTo(.default)
+            }
+
+            // Test 12: RetrievalConfig - Custom Tolerance
+            await runTest(name: "RetrievalConfig - Custom Tolerance") {
+                var config = RetrievalConfig.default
+                // Change by 0.15, default tolerance (0.08) fails, but custom tolerance (0.20) should pass
+                config.vectorWeight += 0.15
+                return !config.isCloseTo(.default) && config.isCloseTo(.default, tolerance: 0.20)
+            }
+
             // Finalize
             await MainActor.run {
                 isRunning = false


### PR DESCRIPTION
🎯 **What:** Added tests for the `isCloseTo` comparison method of `RetrievalConfig` struct in `OpenIntelligence/Core/Models/KnowledgeContainer.swift` since they were missing.

📊 **Coverage:** Covered 4 scenarios: 
- Exact Match (comparing identical presets).
- Within Tolerance (modifying config slightly, within the 0.08 limit).
- Outside Tolerance (modifying config heavily, beyond the 0.08 limit).
- Custom Tolerance (testing that the comparison passes with custom tolerances provided).

✨ **Result:** Enhanced the on-device diagnostic UI suite with testing logic for the `isCloseTo` method, making future refactoring on it safe.

---
*PR created automatically by Jules for task [16818767551954078476](https://jules.google.com/task/16818767551954078476) started by @Gunnarguy*

## Summary by Sourcery

Add diagnostic validation tests for RetrievalConfig isCloseTo behavior in CoreValidationView.

Tests:
- Add diagnostic test to verify RetrievalConfig isCloseTo passes for identical configurations.
- Add diagnostic test to verify RetrievalConfig isCloseTo passes when fields differ within the default tolerance.
- Add diagnostic test to verify RetrievalConfig isCloseTo fails when fields differ beyond the default tolerance.
- Add diagnostic test to verify RetrievalConfig isCloseTo respects a custom tolerance value.