### PR TITLE
🧪 Add tests for LLMModelType migration logic

### DIFF
--- a/OpenIntelligenceTests/Core/Models/LLMModelTypeTests.swift
+++ b/OpenIntelligenceTests/Core/Models/LLMModelTypeTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import OpenIntelligenceEngine
+
+final class LLMModelTypeTests: XCTestCase {
+
+    func testIsDeprecatedRawValue() {
+        // Test deprecated values
+        XCTAssertTrue(LLMModelType.isDeprecatedRawValue("gguf_local"))
+        XCTAssertTrue(LLMModelType.isDeprecatedRawValue("coreml_local"))
+        XCTAssertTrue(LLMModelType.isDeprecatedRawValue("mlx_local"))
+        XCTAssertTrue(LLMModelType.isDeprecatedRawValue("chatgpt_extension"))
+        XCTAssertTrue(LLMModelType.isDeprecatedRawValue("openai"))
+
+        // Test current values
+        XCTAssertFalse(LLMModelType.isDeprecatedRawValue("apple_intelligence"))
+        XCTAssertFalse(LLMModelType.isDeprecatedRawValue("on_device_analysis"))
+
+        // Test unknown/junk values
+        XCTAssertFalse(LLMModelType.isDeprecatedRawValue("random_string"))
+        XCTAssertFalse(LLMModelType.isDeprecatedRawValue(""))
+    }
+
+    func testMigrateFromDeprecated() {
+        XCTAssertEqual(LLMModelType.migrate(from: "gguf_local"), .appleIntelligence)
+        XCTAssertEqual(LLMModelType.migrate(from: "coreml_local"), .appleIntelligence)
+        XCTAssertEqual(LLMModelType.migrate(from: "mlx_local"), .appleIntelligence)
+        XCTAssertEqual(LLMModelType.migrate(from: "chatgpt_extension"), .appleIntelligence)
+        XCTAssertEqual(LLMModelType.migrate(from: "openai"), .appleIntelligence)
+    }
+
+    func testMigrateFromCurrent() {
+        XCTAssertEqual(LLMModelType.migrate(from: "apple_intelligence"), .appleIntelligence)
+        XCTAssertEqual(LLMModelType.migrate(from: "on_device_analysis"), .onDeviceAnalysis)
+    }
+
+    func testMigrateFromUnknownFallback() {
+        XCTAssertEqual(LLMModelType.migrate(from: "random_string"), .appleIntelligence)
+        XCTAssertEqual(LLMModelType.migrate(from: ""), .appleIntelligence)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for `LLMModelType` migration logic was addressed by adding a dedicated `XCTestCase`.
📊 **Coverage:** The tests now cover `.isDeprecatedRawValue` returning `true` for expected values and `false` for others. Additionally, they verify the `migrate(from:)` fallback behavior for deprecated variables to default to `.appleIntelligence` and unknown values, as well as preserving correct assignments.
✨ **Result:** Improved test coverage around deprecated model migration handling, ensuring it functions reliably.

---
*PR created automatically by Jules for task [71308968779673966](https://jules.google.com/task/71308968779673966) started by @Gunnarguy*

## Summary by Sourcery

Add unit tests covering LLMModelType deprecation detection and migration behavior.

Tests:
- Add XCTest coverage for LLMModelType.isDeprecatedRawValue across deprecated, current, and invalid raw values.
- Add tests verifying LLMModelType.migrate(from:) maps deprecated and unknown raw values to appleIntelligence and preserves current model assignments.