### PR TITLE
⚡ Optimize variance calculation by removing redundant array allocation

### DIFF
--- a/OpenIntelligence/Services/Embedding/AdaptiveEmbeddingOptimizer.swift
+++ b/OpenIntelligence/Services/Embedding/AdaptiveEmbeddingOptimizer.swift
@@ -650,9 +650,8 @@ actor LibraryIntelligenceCenter {
         let avgSentenceLength = Double(sentenceLengths.reduce(0, +)) / Double(sentenceLengths.count)
         let avgClausesPerSentence = Double(totalClauses) / Double(sentenceLengths.count)
         let mean = avgSentenceLength
-        let variance = sentenceLengths
-            .map { pow(Double($0) - mean, 2) }
-            .reduce(0, +) / Double(sentenceLengths.count)
+        let variance = sentenceLengths.reduce(0.0) { $0 + pow(Double($1) - mean, 2) }
+            / Double(sentenceLengths.count)
         let stdDev = sqrt(variance)
         let lengthScore = min(1.0, avgSentenceLength / 30.0)
         let clauseScore = min(1.0, max(0, avgClausesPerSentence - 1.0) / 2.0)


### PR DESCRIPTION
💡 **What:** The optimization implemented replaces a `.map` and `.reduce(0, +)` chain with a single `.reduce(0.0)` block, doing the arithmetic for variance inline.
🎯 **Why:** The performance problem it solves is a redundant array allocation. Specifically, computing the differences and squaring them in an intermediate array uses O(N) memory allocation and an extra pass. The single `.reduce` handles it in O(1) memory footprint during aggregation.
📊 **Measured Improvement:** I was unable to show a meaningful performance improvement locally because the current Linux development environment lacks the Swift toolchain (`swift` and `xcodebuild`), making it impossible to compile and benchmark the Swift code directly. However, based on Swift collection conventions, avoiding an O(N) intermediate array allocation when working with map/reduce operations leads to lower memory overhead and fewer cycles on garbage collection overhead, consistently improving variance evaluation execution time.

---
*PR created automatically by Jules for task [15673715069953298091](https://jules.google.com/task/15673715069953298091) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Compute variance of sentence lengths in a single reduction pass to reduce memory usage and improve performance.