### PR TITLE
🧪 Add tests for RetrievalConfig recommendation logic

### DIFF
--- a/OpenIntelligenceTests/Core/Models/RetrievalConfigTests.swift
+++ b/OpenIntelligenceTests/Core/Models/RetrievalConfigTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import OpenIntelligenceEngine
+
+final class RetrievalConfigTests: XCTestCase {
+
+    func testRecommendedConfig_EmptyTypes() {
+        let config = RetrievalConfig.recommended(forDocumentTypes: [])
+        XCTAssertTrue(config.isCloseTo(.default))
+    }
+
+    func testRecommendedConfig_CodeHeavy_Majority() {
+        // total 3, code 2 (> 3/2 = 1)
+        let types: [DocumentType] = [.swift, .python, .pdf]
+        let config = RetrievalConfig.recommended(forDocumentTypes: types)
+        XCTAssertTrue(config.isCloseTo(.technicalManual))
+    }
+
+    func testRecommendedConfig_StructuredDataHeavy_MeetsThreshold() {
+        // total 3, structured 2. structuredDataCount >= 2 (True) && 2 * 3 (6) >= 3 * 2 (6) (True)
+        let types: [DocumentType] = [.csv, .excel, .pdf]
+        let config = RetrievalConfig.recommended(forDocumentTypes: types)
+        XCTAssertTrue(config.isCloseTo(.technicalManual))
+    }
+
+    func testRecommendedConfig_StructuredData_BelowMinimumCount() {
+        // total 1, structured 1. structuredDataCount >= 2 (False)
+        let types: [DocumentType] = [.csv]
+        let config = RetrievalConfig.recommended(forDocumentTypes: types)
+        XCTAssertTrue(config.isCloseTo(.default))
+    }
+
+    func testRecommendedConfig_NarrativeHeavy() {
+        // total 3, narrative 2
+        let types: [DocumentType] = [.pdf, .markdown, .swift]
+        let config = RetrievalConfig.recommended(forDocumentTypes: types)
+        XCTAssertTrue(config.isCloseTo(.default))
+    }
+
+    func testRecommendedConfig_MixedCorpus_Fallback() {
+        // total 4: code 2, structured 1, narrative 1.
+        // code 2 > 2 (False)
+        // structured 1 >= 2 (False)
+        // narrative 1 >= 2 (False)
+        // Falls through to final return .default
+        let types: [DocumentType] = [.swift, .python, .csv, .pdf]
+        let config = RetrievalConfig.recommended(forDocumentTypes: types)
+        XCTAssertTrue(config.isCloseTo(.default))
+    }
+
+    func testRecommendedConfig_AudioVideoAreNarrative() {
+        let types: [DocumentType] = [.audio, .video, .mp3]
+        let config = RetrievalConfig.recommended(forDocumentTypes: types)
+        XCTAssertTrue(config.isCloseTo(.default))
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added tests for KnowledgeContainer.recommended(forDocumentTypes:) logic.

📊 **Coverage:**
- Empty array of document types
- Code heavy corpus (.technicalManual)
- Structured data heavy corpus (.technicalManual)
- Structured data below threshold fallbacks (.default)
- Narrative heavy corpus (.default)
- Mixed corpus fallback (.default)
- Audio and video categorization (.default)

✨ **Result:** Replaces missing test coverage for auto-tuning retrieval settings with a full suite testing all thresholds.

---
*PR created automatically by Jules for task [8762269183184178980](https://jules.google.com/task/8762269183184178980) started by @Gunnarguy*

## Summary by Sourcery

Tests:
- Add test cases for empty, code-heavy, structured-data-heavy, narrative-heavy, mixed, and audio/video document corpora to validate recommended retrieval configuration selection.