### PR TITLE
🧪 Add testing for StructuredAnswer minimumClaimLength

### DIFF
--- a/OpenIntelligence/Core/Models/StructuredAnswer.swift
+++ b/OpenIntelligence/Core/Models/StructuredAnswer.swift
@@ -656,7 +656,7 @@ extension StructuredAnswer {
         }
     }
 
-    nonisolated private static func minimumClaimLength(for answerIntent: AnswerIntent) -> Int {
+    nonisolated internal static func minimumClaimLength(for answerIntent: AnswerIntent) -> Int {
         answerIntent.isExtractiveFirst ? 8 : 20
     }
 

--- a/OpenIntelligenceTests/Core/Models/StructuredAnswerTests.swift
+++ b/OpenIntelligenceTests/Core/Models/StructuredAnswerTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import OpenIntelligenceEngine
+
+final class StructuredAnswerTests: XCTestCase {
+
+    func testMinimumClaimLength_ExtractiveIntents() {
+        let extractiveIntents: [AnswerIntent] = [
+            .lookup, .tableLookup, .procedure, .compare, .compute
+        ]
+
+        for intent in extractiveIntents {
+            XCTAssertEqual(StructuredAnswer.minimumClaimLength(for: intent), 8,
+                           "Expected 8 for extractive intent \(intent)")
+        }
+    }
+
+    func testMinimumClaimLength_NonExtractiveIntents() {
+        let nonExtractiveIntents: [AnswerIntent] = [
+            .summarize, .investigate, .findings
+        ]
+
+        for intent in nonExtractiveIntents {
+            XCTAssertEqual(StructuredAnswer.minimumClaimLength(for: intent), 20,
+                           "Expected 20 for non-extractive intent \(intent)")
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** `minimumClaimLength` in `StructuredAnswer` lacked test coverage because it was a private method.
📊 **Coverage:** Changed the method from `private` to `internal` so that it can be tested from the `OpenIntelligenceTests` target. A new test suite, `StructuredAnswerTests`, was created to verify the behavior of `minimumClaimLength` for both extractive and non-extractive intents.
✨ **Result:** Improved test coverage for `StructuredAnswer` by validating that extractive intents require a shorter length than non-extractive intents.

---
*PR created automatically by Jules for task [4477606766496209025](https://jules.google.com/task/4477606766496209025) started by @Gunnarguy*

## Summary by Sourcery

Add test coverage for StructuredAnswer.minimumClaimLength across extractive and non-extractive answer intents.

Enhancements:
- Relax the visibility of StructuredAnswer.minimumClaimLength to internal to allow testing from the OpenIntelligenceTests target.

Tests:
- Add StructuredAnswerTests to verify minimumClaimLength for extractive intents returns a shorter required length than for non-extractive intents.