### PR TITLE
⚡ [performance improvement description] Unroll delete queries to avoid Array allocations

### DIFF
--- a/OpenIntelligence/Services/Storage/SQLiteFullTextService.swift
+++ b/OpenIntelligence/Services/Storage/SQLiteFullTextService.swift
@@ -1107,35 +1107,41 @@ actor SQLiteFullTextService {
 
     private func deleteStructuredMetadata(documentId: UUID, using db: OpaquePointer?) {
         guard let db else { return }
-        let deletes = [
-            "DELETE FROM chunk_structured WHERE document_id = ?",
-            "DELETE FROM chunk_table_rows WHERE document_id = ?"
-        ]
 
-        for sql in deletes {
-            var statement: OpaquePointer?
-            if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
-                sqlite3_bind_text(statement, 1, documentId.uuidString, -1, SQLITE_TRANSIENT)
-                sqlite3_step(statement)
-                sqlite3_finalize(statement)
-            }
+        var statement: OpaquePointer?
+
+        let sql1 = "DELETE FROM chunk_structured WHERE document_id = ?"
+        if sqlite3_prepare_v2(db, sql1, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, documentId.uuidString, -1, SQLITE_TRANSIENT)
+            sqlite3_step(statement)
+            sqlite3_finalize(statement)
+        }
+
+        let sql2 = "DELETE FROM chunk_table_rows WHERE document_id = ?"
+        if sqlite3_prepare_v2(db, sql2, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, documentId.uuidString, -1, SQLITE_TRANSIENT)
+            sqlite3_step(statement)
+            sqlite3_finalize(statement)
         }
     }
 
     private func deleteStructuredMetadata(containerId: UUID, using db: OpaquePointer?) {
         guard let db else { return }
-        let deletes = [
-            "DELETE FROM chunk_structured WHERE container_id = ?",
-            "DELETE FROM chunk_table_rows WHERE container_id = ?"
-        ]
 
-        for sql in deletes {
-            var statement: OpaquePointer?
-            if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
-                sqlite3_bind_text(statement, 1, containerId.uuidString, -1, SQLITE_TRANSIENT)
-                sqlite3_step(statement)
-                sqlite3_finalize(statement)
-            }
+        var statement: OpaquePointer?
+
+        let sql1 = "DELETE FROM chunk_structured WHERE container_id = ?"
+        if sqlite3_prepare_v2(db, sql1, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, containerId.uuidString, -1, SQLITE_TRANSIENT)
+            sqlite3_step(statement)
+            sqlite3_finalize(statement)
+        }
+
+        let sql2 = "DELETE FROM chunk_table_rows WHERE container_id = ?"
+        if sqlite3_prepare_v2(db, sql2, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, containerId.uuidString, -1, SQLITE_TRANSIENT)
+            sqlite3_step(statement)
+            sqlite3_finalize(statement)
         }
     }
 


### PR DESCRIPTION
💡 **What:** Replaced the array-based loop in `deleteStructuredMetadata` methods with unrolled explicit SQLite statement prepares and executes.

🎯 **Why:** To eliminate the heap allocations and overhead of Swift Arrays and iterators during document and chunk deletion processes.

📊 **Measured Improvement:** As documented during the process, it was not possible to gather precise benchmark measurements due to the lack of the Swift toolchain, `xcodebuild`, and `fastlane` in this development environment (Linux based). However, this optimization is a universally accepted Swift best-practice for small static query sets in performance-sensitive DB layer paths, saving multiple heap allocations per call and matching other similar code paths in the file.

---
*PR created automatically by Jules for task [8004551170782227939](https://jules.google.com/task/8004551170782227939) started by @Gunnarguy*