### PR TITLE
⚡ Optimize vector norm calculation using vDSP

### DIFF
--- a/OpenIntelligence/Services/VectorStore/VectorDatabase.swift
+++ b/OpenIntelligence/Services/VectorStore/VectorDatabase.swift
@@ -315,19 +315,15 @@ class InMemoryVectorDatabase: VectorDatabase {
 
     /// Compute vector norm (magnitude)
     private func computeNorm(_ vector: [Float]) -> Float {
-        var sumSq: Float = 0.0
-        vDSP_svesq(vector, 1, &sumSq, vDSP_Length(vector.count))
-        return sqrt(sumSq)
+        return sqrt(vDSP.sumOfSquares(vector))
     }
 
     /// Optimized cosine similarity using pre-computed norms
     private func optimizedCosineSimilarity(_ a: [Float], _ b: [Float], queryNorm: Float, chunkNorm: Float) -> Float {
-        guard a.count == b.count else { return 0.0 }
+        guard a.count == b.count, !a.isEmpty else { return 0.0 }
 
         var dotProduct: Float = 0.0
-        for i in 0..<a.count {
-            dotProduct += a[i] * b[i]
-        }
+        vDSP_dotpr(a, 1, b, 1, &dotProduct, vDSP_Length(a.count))
 
         let magnitude = queryNorm * chunkNorm
         guard magnitude > 0 else { return 0.0 }
@@ -336,19 +332,15 @@ class InMemoryVectorDatabase: VectorDatabase {
     }
 
     private func cosineSimilarity(_ a: [Float], _ b: [Float]) -> Float {
-        guard a.count == b.count else { return 0.0 }
+        guard a.count == b.count, !a.isEmpty else { return 0.0 }
 
         var dotProduct: Float = 0.0
-        var magnitudeA: Float = 0.0
-        var magnitudeB: Float = 0.0
+        vDSP_dotpr(a, 1, b, 1, &dotProduct, vDSP_Length(a.count))
 
-        for i in 0..<a.count {
-            dotProduct += a[i] * b[i]
-            magnitudeA += a[i] * a[i]
-            magnitudeB += b[i] * b[i]
-        }
+        let magnitudeA = sqrt(vDSP.sumOfSquares(a))
+        let magnitudeB = sqrt(vDSP.sumOfSquares(b))
 
-        let magnitude = sqrt(magnitudeA) * sqrt(magnitudeB)
+        let magnitude = magnitudeA * magnitudeB
         guard magnitude > 0 else { return 0.0 }
 
         return dotProduct / magnitude

--- a/OpenIntelligence/Services/VectorStore/VectorDatabase.swift
+++ b/OpenIntelligence/Services/VectorStore/VectorDatabase.swift
@@ -315,9 +315,7 @@ class InMemoryVectorDatabase: VectorDatabase {
 
     /// Compute vector norm (magnitude)
     private func computeNorm(_ vector: [Float]) -> Float {
-        var sumSq: Float = 0.0
-        vDSP_svesq(vector, 1, &sumSq, vDSP_Length(vector.count))
-        return sqrt(sumSq)
+        return sqrt(vDSP.sumOfSquares(vector))
     }
 
     /// Optimized cosine similarity using pre-computed norms
@@ -339,14 +337,8 @@ class InMemoryVectorDatabase: VectorDatabase {
         var dotProduct: Float = 0.0
         vDSP_dotpr(a, 1, b, 1, &dotProduct, vDSP_Length(a.count))
 
-        var sumSqA: Float = 0.0
-        vDSP_svesq(a, 1, &sumSqA, vDSP_Length(a.count))
-
-        var sumSqB: Float = 0.0
-        vDSP_svesq(b, 1, &sumSqB, vDSP_Length(b.count))
-
-        let magnitudeA = sqrt(sumSqA)
-        let magnitudeB = sqrt(sumSqB)
+        let magnitudeA = sqrt(vDSP.sumOfSquares(a))
+        let magnitudeB = sqrt(vDSP.sumOfSquares(b))
 
         let magnitude = magnitudeA * magnitudeB
         guard magnitude > 0 else { return 0.0 }

--- a/OpenIntelligence/Services/VectorStore/VectorDatabase.swift
+++ b/OpenIntelligence/Services/VectorStore/VectorDatabase.swift
@@ -315,7 +315,9 @@ class InMemoryVectorDatabase: VectorDatabase {
 
     /// Compute vector norm (magnitude)
     private func computeNorm(_ vector: [Float]) -> Float {
-        return sqrt(vDSP.sumOfSquares(vector))
+        var sumSq: Float = 0.0
+        vDSP_svesq(vector, 1, &sumSq, vDSP_Length(vector.count))
+        return sqrt(sumSq)
     }
 
     /// Optimized cosine similarity using pre-computed norms
@@ -337,8 +339,14 @@ class InMemoryVectorDatabase: VectorDatabase {
         var dotProduct: Float = 0.0
         vDSP_dotpr(a, 1, b, 1, &dotProduct, vDSP_Length(a.count))
 
-        let magnitudeA = sqrt(vDSP.sumOfSquares(a))
-        let magnitudeB = sqrt(vDSP.sumOfSquares(b))
+        var sumSqA: Float = 0.0
+        vDSP_svesq(a, 1, &sumSqA, vDSP_Length(a.count))
+
+        var sumSqB: Float = 0.0
+        vDSP_svesq(b, 1, &sumSqB, vDSP_Length(b.count))
+
+        let magnitudeA = sqrt(sumSqA)
+        let magnitudeB = sqrt(sumSqB)
 
         let magnitude = magnitudeA * magnitudeB
         guard magnitude > 0 else { return 0.0 }

--- a/OpenIntelligence/Services/VectorStore/VectorDatabase.swift
+++ b/OpenIntelligence/Services/VectorStore/VectorDatabase.swift
@@ -315,11 +315,9 @@ class InMemoryVectorDatabase: VectorDatabase {
 
     /// Compute vector norm (magnitude)
     private func computeNorm(_ vector: [Float]) -> Float {
-        var sum: Float = 0.0
-        for value in vector {
-            sum += value * value
-        }
-        return sqrt(sum)
+        var sumSq: Float = 0.0
+        vDSP_svesq(vector, 1, &sumSq, vDSP_Length(vector.count))
+        return sqrt(sumSq)
     }
 
     /// Optimized cosine similarity using pre-computed norms


### PR DESCRIPTION
💡 **What:** Replaced the manual for-in loop in `computeNorm` with `vDSP_svesq` from the Accelerate framework.
🎯 **Why:** The manual loop computes the sum of squares element-by-element on the CPU, which is inefficient for large vectors. Using `vDSP_svesq` leverages hardware acceleration (SIMD instructions) to perform the same operation much faster.
📊 **Measured Improvement:** We were unable to provide a local baseline benchmark metric as the `swift` and `xcodebuild` toolchains are unavailable in the test environment (`swift: command not found`). However, `vDSP` uses SIMD/NEON instructions which generally yield a 2x-10x speedup for floating-point array operations compared to manual loops in Swift.

---
*PR created automatically by Jules for task [7076956494474147480](https://jules.google.com/task/7076956494474147480) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Replace manual sum-of-squares loop in computeNorm with vDSP_svesq to leverage hardware-accelerated SIMD operations.