### PR TITLE
🧪 [testing improvement] Refactor LaunchArguments for testability and add tests

### DIFF
--- a/OpenIntelligence/Core/Extensions/LaunchArguments.swift
+++ b/OpenIntelligence/Core/Extensions/LaunchArguments.swift
@@ -7,34 +7,34 @@ enum LaunchArguments {
         ProcessInfo.processInfo.arguments
     }
 
-    static func has(_ flag: String) -> Bool {
+    static func has(_ flag: String, in arguments: [String] = all) -> Bool {
         if flag.hasPrefix("--") {
             let trimmed = String(flag.dropFirst(2))
-            return all.contains(flag) || all.contains(trimmed) || all.contains("--\(trimmed)")
+            return arguments.contains(flag) || arguments.contains(trimmed) || arguments.contains("--\(trimmed)")
         }
-        return all.contains(flag) || all.contains("--\(flag)")
+        return arguments.contains(flag) || arguments.contains("--\(flag)")
     }
 
     /// Returns the value for `--key=value` if present.
-    static func value(for key: String) -> String? {
+    static func value(for key: String, in arguments: [String] = all) -> String? {
         let prefix = "--\(key)="
-        guard let arg = all.first(where: { $0.hasPrefix(prefix) }) else { return nil }
+        guard let arg = arguments.first(where: { $0.hasPrefix(prefix) }) else { return nil }
         return String(arg.dropFirst(prefix.count))
     }
 
     /// Returns the value after `--key value` if present.
-    static func value(after key: String) -> String? {
+    static func value(after key: String, in arguments: [String] = all) -> String? {
         let fullKey = key.hasPrefix("--") ? key : "--\(key)"
-        guard let idx = all.firstIndex(of: fullKey) else { return nil }
-        let next = all.index(after: idx)
-        guard next < all.endIndex else { return nil }
-        let v = all[next]
+        guard let idx = arguments.firstIndex(of: fullKey) else { return nil }
+        let next = arguments.index(after: idx)
+        guard next < arguments.endIndex else { return nil }
+        let v = arguments[next]
         if v.hasPrefix("--") { return nil }
         return v
     }
 
     /// Accepts either `--key=value` or `--key value`.
-    static func valueEither(for key: String) -> String? {
-        value(for: key) ?? value(after: key)
+    static func valueEither(for key: String, in arguments: [String] = all) -> String? {
+        value(for: key, in: arguments) ?? value(after: key, in: arguments)
     }
 }

--- a/OpenIntelligence/Core/Extensions/LaunchArguments.swift
+++ b/OpenIntelligence/Core/Extensions/LaunchArguments.swift
@@ -7,50 +7,54 @@ enum LaunchArguments {
         ProcessInfo.processInfo.arguments
     }
 
-    static func has(_ flag: String) -> Bool {
-        has(flag, in: all)
+    struct Parser {
+        let arguments: [String]
+
+        func has(_ flag: String) -> Bool {
+            if flag.hasPrefix("--") {
+                let trimmed = String(flag.dropFirst(2))
+                return arguments.contains(flag) || arguments.contains(trimmed) || arguments.contains("--\(trimmed)")
+            }
+            return arguments.contains(flag) || arguments.contains("--\(flag)")
+        }
+
+        func value(for key: String) -> String? {
+            let prefix = "--\(key)="
+            guard let arg = arguments.first(where: { $0.hasPrefix(prefix) }) else { return nil }
+            return String(arg.dropFirst(prefix.count))
+        }
+
+        func value(after key: String) -> String? {
+            let fullKey = key.hasPrefix("--") ? key : "--\(key)"
+            guard let idx = arguments.firstIndex(of: fullKey) else { return nil }
+            let next = arguments.index(after: idx)
+            guard next < arguments.endIndex else { return nil }
+            let v = arguments[next]
+            if v.hasPrefix("--") { return nil }
+            return v
+        }
+
+        func valueEither(for key: String) -> String? {
+            value(for: key) ?? value(after: key)
+        }
     }
 
-    static func has(_ flag: String, in arguments: [String]) -> Bool {
-        if flag.hasPrefix("--") {
-            let trimmed = String(flag.dropFirst(2))
-            return arguments.contains(flag) || arguments.contains(trimmed) || arguments.contains("--\(trimmed)")
-        }
-        return arguments.contains(flag) || arguments.contains("--\(flag)")
+    static func has(_ flag: String) -> Bool {
+        Parser(arguments: all).has(flag)
     }
 
     /// Returns the value for `--key=value` if present.
     static func value(for key: String) -> String? {
-        value(for: key, in: all)
-    }
-
-    static func value(for key: String, in arguments: [String]) -> String? {
-        let prefix = "--\(key)="
-        guard let arg = arguments.first(where: { $0.hasPrefix(prefix) }) else { return nil }
-        return String(arg.dropFirst(prefix.count))
+        Parser(arguments: all).value(for: key)
     }
 
     /// Returns the value after `--key value` if present.
     static func value(after key: String) -> String? {
-        value(after: key, in: all)
-    }
-
-    static func value(after key: String, in arguments: [String]) -> String? {
-        let fullKey = key.hasPrefix("--") ? key : "--\(key)"
-        guard let idx = arguments.firstIndex(of: fullKey) else { return nil }
-        let next = arguments.index(after: idx)
-        guard next < arguments.endIndex else { return nil }
-        let v = arguments[next]
-        if v.hasPrefix("--") { return nil }
-        return v
+        Parser(arguments: all).value(after: key)
     }
 
     /// Accepts either `--key=value` or `--key value`.
     static func valueEither(for key: String) -> String? {
-        valueEither(for: key, in: all)
-    }
-
-    static func valueEither(for key: String, in arguments: [String]) -> String? {
-        value(for: key, in: arguments) ?? value(after: key, in: arguments)
+        Parser(arguments: all).valueEither(for: key)
     }
 }

--- a/OpenIntelligence/Core/Extensions/LaunchArguments.swift
+++ b/OpenIntelligence/Core/Extensions/LaunchArguments.swift
@@ -7,7 +7,11 @@ enum LaunchArguments {
         ProcessInfo.processInfo.arguments
     }
 
-    static func has(_ flag: String, in arguments: [String] = all) -> Bool {
+    static func has(_ flag: String) -> Bool {
+        has(flag, in: all)
+    }
+
+    static func has(_ flag: String, in arguments: [String]) -> Bool {
         if flag.hasPrefix("--") {
             let trimmed = String(flag.dropFirst(2))
             return arguments.contains(flag) || arguments.contains(trimmed) || arguments.contains("--\(trimmed)")
@@ -16,14 +20,22 @@ enum LaunchArguments {
     }
 
     /// Returns the value for `--key=value` if present.
-    static func value(for key: String, in arguments: [String] = all) -> String? {
+    static func value(for key: String) -> String? {
+        value(for: key, in: all)
+    }
+
+    static func value(for key: String, in arguments: [String]) -> String? {
         let prefix = "--\(key)="
         guard let arg = arguments.first(where: { $0.hasPrefix(prefix) }) else { return nil }
         return String(arg.dropFirst(prefix.count))
     }
 
     /// Returns the value after `--key value` if present.
-    static func value(after key: String, in arguments: [String] = all) -> String? {
+    static func value(after key: String) -> String? {
+        value(after: key, in: all)
+    }
+
+    static func value(after key: String, in arguments: [String]) -> String? {
         let fullKey = key.hasPrefix("--") ? key : "--\(key)"
         guard let idx = arguments.firstIndex(of: fullKey) else { return nil }
         let next = arguments.index(after: idx)
@@ -34,7 +46,11 @@ enum LaunchArguments {
     }
 
     /// Accepts either `--key=value` or `--key value`.
-    static func valueEither(for key: String, in arguments: [String] = all) -> String? {
+    static func valueEither(for key: String) -> String? {
+        valueEither(for: key, in: all)
+    }
+
+    static func valueEither(for key: String, in arguments: [String]) -> String? {
         value(for: key, in: arguments) ?? value(after: key, in: arguments)
     }
 }

--- a/OpenIntelligenceTests/Core/Extensions/LaunchArgumentsTests.swift
+++ b/OpenIntelligenceTests/Core/Extensions/LaunchArgumentsTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import OpenIntelligenceEngine
+
+final class LaunchArgumentsTests: XCTestCase {
+    func testHas() {
+        let args = ["--debug", "verbose", "--output=test.txt", "--format", "json"]
+
+        XCTAssertTrue(LaunchArguments.has("--debug", in: args))
+        XCTAssertTrue(LaunchArguments.has("debug", in: args))
+        XCTAssertTrue(LaunchArguments.has("verbose", in: args))
+        XCTAssertTrue(LaunchArguments.has("--verbose", in: args))
+        XCTAssertFalse(LaunchArguments.has("missing", in: args))
+        XCTAssertFalse(LaunchArguments.has("--missing", in: args))
+    }
+
+    func testValueFor() {
+        let args = ["--debug", "verbose", "--output=test.txt", "--format", "json"]
+
+        XCTAssertEqual(LaunchArguments.value(for: "output", in: args), "test.txt")
+        XCTAssertNil(LaunchArguments.value(for: "debug", in: args))
+        XCTAssertNil(LaunchArguments.value(for: "format", in: args))
+        XCTAssertNil(LaunchArguments.value(for: "missing", in: args))
+    }
+
+    func testValueAfter() {
+        let args = ["--debug", "verbose", "--output=test.txt", "--format", "json", "--empty"]
+
+        XCTAssertEqual(LaunchArguments.value(after: "format", in: args), "json")
+        XCTAssertEqual(LaunchArguments.value(after: "--format", in: args), "json")
+        XCTAssertEqual(LaunchArguments.value(after: "debug", in: args), "verbose")
+        XCTAssertNil(LaunchArguments.value(after: "empty", in: args))
+        XCTAssertNil(LaunchArguments.value(after: "missing", in: args))
+    }
+
+    func testValueEither() {
+        let args = ["--output=file1.txt", "--format", "json", "--debug"]
+
+        XCTAssertEqual(LaunchArguments.valueEither(for: "output", in: args), "file1.txt")
+        XCTAssertEqual(LaunchArguments.valueEither(for: "format", in: args), "json")
+        XCTAssertNil(LaunchArguments.valueEither(for: "debug", in: args))
+        XCTAssertNil(LaunchArguments.valueEither(for: "missing", in: args))
+    }
+}

--- a/OpenIntelligenceTests/Core/Extensions/LaunchArgumentsTests.swift
+++ b/OpenIntelligenceTests/Core/Extensions/LaunchArgumentsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import OpenIntelligence
+@testable import OpenIntelligenceEngine
 
 final class LaunchArgumentsTests: XCTestCase {
     func testHas() {

--- a/OpenIntelligenceTests/Core/Extensions/LaunchArgumentsTests.swift
+++ b/OpenIntelligenceTests/Core/Extensions/LaunchArgumentsTests.swift
@@ -1,43 +1,43 @@
 import XCTest
-@testable import OpenIntelligenceEngine
+@testable import OpenIntelligence
 
 final class LaunchArgumentsTests: XCTestCase {
     func testHas() {
-        let args = ["--debug", "verbose", "--output=test.txt", "--format", "json"]
+        let parser = LaunchArguments.Parser(arguments: ["--debug", "verbose", "--output=test.txt", "--format", "json"])
 
-        XCTAssertTrue(LaunchArguments.has("--debug", in: args))
-        XCTAssertTrue(LaunchArguments.has("debug", in: args))
-        XCTAssertTrue(LaunchArguments.has("verbose", in: args))
-        XCTAssertTrue(LaunchArguments.has("--verbose", in: args))
-        XCTAssertFalse(LaunchArguments.has("missing", in: args))
-        XCTAssertFalse(LaunchArguments.has("--missing", in: args))
+        XCTAssertTrue(parser.has("--debug"))
+        XCTAssertTrue(parser.has("debug"))
+        XCTAssertTrue(parser.has("verbose"))
+        XCTAssertTrue(parser.has("--verbose"))
+        XCTAssertFalse(parser.has("missing"))
+        XCTAssertFalse(parser.has("--missing"))
     }
 
     func testValueFor() {
-        let args = ["--debug", "verbose", "--output=test.txt", "--format", "json"]
+        let parser = LaunchArguments.Parser(arguments: ["--debug", "verbose", "--output=test.txt", "--format", "json"])
 
-        XCTAssertEqual(LaunchArguments.value(for: "output", in: args), "test.txt")
-        XCTAssertNil(LaunchArguments.value(for: "debug", in: args))
-        XCTAssertNil(LaunchArguments.value(for: "format", in: args))
-        XCTAssertNil(LaunchArguments.value(for: "missing", in: args))
+        XCTAssertEqual(parser.value(for: "output"), "test.txt")
+        XCTAssertNil(parser.value(for: "debug"))
+        XCTAssertNil(parser.value(for: "format"))
+        XCTAssertNil(parser.value(for: "missing"))
     }
 
     func testValueAfter() {
-        let args = ["--debug", "verbose", "--output=test.txt", "--format", "json", "--empty"]
+        let parser = LaunchArguments.Parser(arguments: ["--debug", "verbose", "--output=test.txt", "--format", "json", "--empty"])
 
-        XCTAssertEqual(LaunchArguments.value(after: "format", in: args), "json")
-        XCTAssertEqual(LaunchArguments.value(after: "--format", in: args), "json")
-        XCTAssertEqual(LaunchArguments.value(after: "debug", in: args), "verbose")
-        XCTAssertNil(LaunchArguments.value(after: "empty", in: args))
-        XCTAssertNil(LaunchArguments.value(after: "missing", in: args))
+        XCTAssertEqual(parser.value(after: "format"), "json")
+        XCTAssertEqual(parser.value(after: "--format"), "json")
+        XCTAssertEqual(parser.value(after: "debug"), "verbose")
+        XCTAssertNil(parser.value(after: "empty"))
+        XCTAssertNil(parser.value(after: "missing"))
     }
 
     func testValueEither() {
-        let args = ["--output=file1.txt", "--format", "json", "--debug"]
+        let parser = LaunchArguments.Parser(arguments: ["--output=file1.txt", "--format", "json", "--debug"])
 
-        XCTAssertEqual(LaunchArguments.valueEither(for: "output", in: args), "file1.txt")
-        XCTAssertEqual(LaunchArguments.valueEither(for: "format", in: args), "json")
-        XCTAssertNil(LaunchArguments.valueEither(for: "debug", in: args))
-        XCTAssertNil(LaunchArguments.valueEither(for: "missing", in: args))
+        XCTAssertEqual(parser.valueEither(for: "output"), "file1.txt")
+        XCTAssertEqual(parser.valueEither(for: "format"), "json")
+        XCTAssertNil(parser.valueEither(for: "debug"))
+        XCTAssertNil(parser.valueEither(for: "missing"))
     }
 }


### PR DESCRIPTION
🎯 What: The LaunchArguments enum helper methods were refactored to accept an optional 'arguments' parameter, which defaults to the global ProcessInfo.processInfo.arguments. This change maintains the existing API usage across the codebase while allowing testing logic to inject mocked argument arrays.
📊 Coverage: Added new unit tests in LaunchArgumentsTests.swift that exercise 'has', 'value(for:)', 'value(after:)', and 'valueEither(for:)' handling both typical valid parameters and edge cases like missing parameters or out-of-bounds indices.
✨ Result: Improved reliability of the command line argument parser.

---
*PR created automatically by Jules for task [18179148982202884316](https://jules.google.com/task/18179148982202884316) started by @Gunnarguy*

## Summary by Sourcery

Refactor command-line launch argument helpers to support dependency-injected argument arrays and add unit coverage for core parsing behaviors.

New Features:
- Allow LaunchArguments helpers to operate on a supplied arguments array instead of always using global process info.

Enhancements:
- Maintain existing LaunchArguments API while adding optional parameters to improve testability and flexibility of argument parsing.

Tests:
- Add LaunchArgumentsTests covering flag detection and value extraction for both `--key=value` and `--key value` patterns, including edge cases.