### PR TITLE
fix: improve specification lookup detection to use word boundaries

### DIFF
--- a/OpenIntelligence/Services/Query/Enhancement/QueryEnhancementService.swift
+++ b/OpenIntelligence/Services/Query/Enhancement/QueryEnhancementService.swift
@@ -578,7 +578,7 @@ final class QueryEnhancementService {
             "catalog number", "item number", "product code", "sku"
         ]
         for pattern in embeddedLookupPatterns {
-            if lower.range(of: "\\b\(pattern)s?\\b", options: .regularExpression) != nil {
+            if lower.range(of: "(?i)\\b\(pattern)s?\\b", options: .regularExpression) != nil {
                 Log.debug("[QueryEnhancement] Detected embedded lookup pattern: '\(pattern)'", category: .retrieval)
                 return .lookup
             }
@@ -592,7 +592,7 @@ final class QueryEnhancementService {
             "should i use"
         ]
         for pattern in specLookupPatterns {
-            if lower.range(of: "\\b\(pattern)s?\\b", options: .regularExpression) != nil {
+            if lower.range(of: "(?i)\\b\(pattern)s?\\b", options: .regularExpression) != nil {
                 Log.debug("[QueryEnhancement] Detected spec lookup pattern: '\(pattern)'", category: .retrieval)
                 return .lookup
             }

--- a/OpenIntelligence/Services/Query/Enhancement/QueryEnhancementService.swift
+++ b/OpenIntelligence/Services/Query/Enhancement/QueryEnhancementService.swift
@@ -578,7 +578,7 @@ final class QueryEnhancementService {
             "catalog number", "item number", "product code", "sku"
         ]
         for pattern in embeddedLookupPatterns {
-            if lower.contains(pattern) {
+            if lower.range(of: "\\b\(pattern)s?\\b", options: .regularExpression) != nil {
                 Log.debug("[QueryEnhancement] Detected embedded lookup pattern: '\(pattern)'", category: .retrieval)
                 return .lookup
             }
@@ -592,7 +592,7 @@ final class QueryEnhancementService {
             "should i use"
         ]
         for pattern in specLookupPatterns {
-            if lower.contains(pattern) {
+            if lower.range(of: "\\b\(pattern)s?\\b", options: .regularExpression) != nil {
                 Log.debug("[QueryEnhancement] Detected spec lookup pattern: '\(pattern)'", category: .retrieval)
                 return .lookup
             }

--- a/OpenIntelligence/Services/Query/Enhancement/QueryEnhancementService.swift
+++ b/OpenIntelligence/Services/Query/Enhancement/QueryEnhancementService.swift
@@ -578,7 +578,7 @@ final class QueryEnhancementService {
             "catalog number", "item number", "product code", "sku"
         ]
         for pattern in embeddedLookupPatterns {
-            if lower.range(of: "\\b\(pattern)s?\\b", options: [.regularExpression, .caseInsensitive]) != nil {
+            if lower.range(of: "\\b\(pattern)s?\\b", options: .regularExpression) != nil {
                 Log.debug("[QueryEnhancement] Detected embedded lookup pattern: '\(pattern)'", category: .retrieval)
                 return .lookup
             }
@@ -592,7 +592,7 @@ final class QueryEnhancementService {
             "should i use"
         ]
         for pattern in specLookupPatterns {
-            if lower.range(of: "\\b\(pattern)s?\\b", options: [.regularExpression, .caseInsensitive]) != nil {
+            if lower.range(of: "\\b\(pattern)s?\\b", options: .regularExpression) != nil {
                 Log.debug("[QueryEnhancement] Detected spec lookup pattern: '\(pattern)'", category: .retrieval)
                 return .lookup
             }

--- a/OpenIntelligence/Services/Query/Enhancement/QueryEnhancementService.swift
+++ b/OpenIntelligence/Services/Query/Enhancement/QueryEnhancementService.swift
@@ -578,7 +578,7 @@ final class QueryEnhancementService {
             "catalog number", "item number", "product code", "sku"
         ]
         for pattern in embeddedLookupPatterns {
-            if lower.range(of: "\\b\(pattern)s?\\b", options: .regularExpression) != nil {
+            if lower.range(of: "\\b\(pattern)s?\\b", options: [.regularExpression, .caseInsensitive]) != nil {
                 Log.debug("[QueryEnhancement] Detected embedded lookup pattern: '\(pattern)'", category: .retrieval)
                 return .lookup
             }
@@ -592,7 +592,7 @@ final class QueryEnhancementService {
             "should i use"
         ]
         for pattern in specLookupPatterns {
-            if lower.range(of: "\\b\(pattern)s?\\b", options: .regularExpression) != nil {
+            if lower.range(of: "\\b\(pattern)s?\\b", options: [.regularExpression, .caseInsensitive]) != nil {
                 Log.debug("[QueryEnhancement] Detected spec lookup pattern: '\(pattern)'", category: .retrieval)
                 return .lookup
             }


### PR DESCRIPTION
Replaced simple substring matching (.contains) with regular expression matching using word boundaries (\b) and an optional plural s (s?) for both embeddedLookupPatterns and specLookupPatterns. This prevents false positive matches where the pattern is just a substring of another word (e.g., 'sku' matching 'skull' or 'weight' matching 'overweight').

---
*PR created automatically by Jules for task [15883213411637904570](https://jules.google.com/task/15883213411637904570) started by @Gunnarguy*

## Summary by Sourcery

Bug Fixes:
- Prevent specification lookup patterns like 'sku' or 'weight' from triggering on longer words that merely contain them as substrings by enforcing word boundaries and optional plural forms in detection.