### PR TITLE
Use .advanced property when available

### DIFF
--- a/OpenIntelligence/Services/AIPlatform/AppleFoundationModels/FoundationModelSessionFactory.swift
+++ b/OpenIntelligence/Services/AIPlatform/AppleFoundationModels/FoundationModelSessionFactory.swift
@@ -54,11 +54,14 @@ struct FoundationModelSessionFactory {
             }
             
         case .onDeviceAdvanced:
-            #if compiler(>=6.4)
             if #available(iOS 27.0, macOS 27.0, *) {
                 // Initialize the native AFM 3 Core Advanced (20B) on-device model.
                 // This runs locally on Apple Silicon without requiring Private Cloud Compute entitlements.
+                #if compiler(>=6.4)
                 let model = SystemLanguageModel.advanced
+                #else
+                let model = SystemLanguageModel.default
+                #endif
                 guard case .available = model.availability else { throw LLMError.modelUnavailable }
                 if let savedTranscript = pendingTranscript, !disableTools {
                     finalSession = LanguageModelSession(model: model, tools: tools, transcript: savedTranscript)
@@ -80,19 +83,6 @@ struct FoundationModelSessionFactory {
                     finalSession = LanguageModelSession(model: model, tools: tools, instructions: Instructions(instructionsText))
                 }
             }
-            #else
-            // Graceful fallback to the standard model for iOS 26 users
-            let model = SystemLanguageModel.default
-            guard case .available = model.availability else { throw LLMError.modelUnavailable }
-            selectedRoute = .onDevice // Update selected route for telemetry to reflect fallback
-            if let savedTranscript = pendingTranscript, !disableTools {
-                finalSession = LanguageModelSession(model: model, tools: tools, transcript: savedTranscript)
-                finalSession.prewarm()
-                transcriptConsumed = true
-            } else {
-                finalSession = LanguageModelSession(model: model, tools: tools, instructions: Instructions(instructionsText))
-            }
-            #endif
             
         case .privateCloudCompute(_):
             #if compiler(>=6.4)

--- a/OpenIntelligence/Services/AIPlatform/AppleFoundationModels/FoundationModelSessionFactory.swift
+++ b/OpenIntelligence/Services/AIPlatform/AppleFoundationModels/FoundationModelSessionFactory.swift
@@ -57,7 +57,7 @@ struct FoundationModelSessionFactory {
             if #available(iOS 27.0, macOS 27.0, *) {
                 // Initialize the native AFM 3 Core Advanced (20B) on-device model.
                 // This runs locally on Apple Silicon without requiring Private Cloud Compute entitlements.
-                let model = SystemLanguageModel.default
+                let model = SystemLanguageModel.advanced
                 guard case .available = model.availability else { throw LLMError.modelUnavailable }
                 if let savedTranscript = pendingTranscript, !disableTools {
                     finalSession = LanguageModelSession(model: model, tools: tools, transcript: savedTranscript)

--- a/OpenIntelligence/Services/AIPlatform/AppleFoundationModels/FoundationModelSessionFactory.swift
+++ b/OpenIntelligence/Services/AIPlatform/AppleFoundationModels/FoundationModelSessionFactory.swift
@@ -54,6 +54,7 @@ struct FoundationModelSessionFactory {
             }
             
         case .onDeviceAdvanced:
+            #if compiler(>=6.4)
             if #available(iOS 27.0, macOS 27.0, *) {
                 // Initialize the native AFM 3 Core Advanced (20B) on-device model.
                 // This runs locally on Apple Silicon without requiring Private Cloud Compute entitlements.
@@ -79,6 +80,19 @@ struct FoundationModelSessionFactory {
                     finalSession = LanguageModelSession(model: model, tools: tools, instructions: Instructions(instructionsText))
                 }
             }
+            #else
+            // Graceful fallback to the standard model for iOS 26 users
+            let model = SystemLanguageModel.default
+            guard case .available = model.availability else { throw LLMError.modelUnavailable }
+            selectedRoute = .onDevice // Update selected route for telemetry to reflect fallback
+            if let savedTranscript = pendingTranscript, !disableTools {
+                finalSession = LanguageModelSession(model: model, tools: tools, transcript: savedTranscript)
+                finalSession.prewarm()
+                transcriptConsumed = true
+            } else {
+                finalSession = LanguageModelSession(model: model, tools: tools, instructions: Instructions(instructionsText))
+            }
+            #endif
             
         case .privateCloudCompute(_):
             #if compiler(>=6.4)


### PR DESCRIPTION
The `.advanced` property for the 20B model is now available in the Xcode 18 Beta SDK. I have replaced the temporary workaround `SystemLanguageModel.default` with `SystemLanguageModel.advanced` for the `.onDeviceAdvanced` route.

---
*PR created automatically by Jules for task [15307636068458154873](https://jules.google.com/task/15307636068458154873) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Update the .onDeviceAdvanced session path to use the dedicated advanced system language model instead of the default model.