### PR TITLE
Fix: Blend original query and hypothetical document

### DIFF
--- a/OpenIntelligence/Services/Query/Rewriting/HyDEService.swift
+++ b/OpenIntelligence/Services/Query/Rewriting/HyDEService.swift
@@ -173,7 +173,12 @@ final class HyDEService: @unchecked Sendable {
         }
 
         // UNIVERSAL FIX: Blend original query + hypothetical document for embedding.
-        // This ensures the original query terms aren't lost in the generated text.
+        // Previously used ONLY the hypothetical doc, which meant a hallucinated hypothetical
+        // (e.g., "Drug X is typically 500mg" when the answer is 250mg) would pull retrieval
+        // entirely in the wrong direction with zero safety net.
+        // Now: concatenate both so the embedding captures BOTH the query intent vocabulary
+        // AND the hypothetical answer vocabulary. MiniLM handles this well since the combined
+        // text is still well under 510 tokens.
         let blendedText = "\(query) \(groundedDoc)"
 
         return HyDEResult(

--- a/OpenIntelligence/Services/Query/Rewriting/HyDEService.swift
+++ b/OpenIntelligence/Services/Query/Rewriting/HyDEService.swift
@@ -173,13 +173,8 @@ final class HyDEService: @unchecked Sendable {
         }
 
         // UNIVERSAL FIX: Blend original query + hypothetical document for embedding.
-        // Previously used ONLY the hypothetical doc, which meant a hallucinated hypothetical
-        // (e.g., "Drug X is typically 500mg" when the answer is 250mg) would pull retrieval
-        // entirely in the wrong direction with zero safety net.
-        // Now: concatenate both so the embedding captures BOTH the query intent vocabulary
-        // AND the hypothetical answer vocabulary. MiniLM handles this well since the combined
-        // text is still well under 510 tokens.
-        let blendedText = "\(query)\n\(groundedDoc)"
+        // This ensures the original query terms aren't lost in the generated text.
+        let blendedText = "\(query) \(groundedDoc)"
 
         return HyDEResult(
             originalQuery: query,


### PR DESCRIPTION
Edited `OpenIntelligence/Services/Query/Rewriting/HyDEService.swift` around line 175 to change `let blendedText = "\(query)\n\(groundedDoc)"` to `let blendedText = "\(query) \(groundedDoc)"`, and updated the comment to match the required explanation ("This ensures the original query terms aren't lost in the generated text.") to properly blend the original query with the hypothetical document as requested.

---
*PR created automatically by Jules for task [17201008342966294973](https://jules.google.com/task/17201008342966294973) started by @Gunnarguy*

## Summary by Sourcery

Adjust query–document blending in HyDEService to preserve original query terms in the generated embedding text.

Bug Fixes:
- Prevent loss of original query vocabulary when blending the query with the hypothetical document for embeddings.

Enhancements:
- Clarify HyDEService documentation comment explaining the rationale for blending the original query with the hypothetical document.