### PR TITLE
Fix: Gap 2 - Utilize PDFKit native word count for OCR fallback qualityScore

### DIFF
--- a/OpenIntelligence/Services/Document/Processing/StructuredDocumentParser.swift
+++ b/OpenIntelligence/Services/Document/Processing/StructuredDocumentParser.swift
@@ -652,13 +652,23 @@ actor StructuredDocumentParser {
                 let fallbackCG = fullResImageCG() ?? structureCG
                 let fallbackText = try await performTextRecognitionFallback(on: fallbackCG, customWords: customWords)
                 if !fallbackText.isEmpty {
+                    let extractedCount = fallbackText.split(separator: " ").count
+                    var qualityScore = 0.5
+
+                    // Gap 2 fix: use PDFKit native word count as ground truth denominator when provided.
+                    // This prevents artificial 100% scores when both OCR and extraction fail.
+                    if let nativeCount = nativeWordCount, nativeCount > 0 {
+                        qualityScore = min(1.0, Double(extractedCount) / Double(nativeCount))
+                    }
+
                     let elapsed = Date().timeIntervalSince(startTime)
-                    Log.info("[StructuredDocumentParser] RecognizeTextRequest captured \(fallbackText.split(separator: " ").count) words on page \(pageNumber) in \(String(format: "%.2f", elapsed))s", category: .ingestion)
+                    Log.info("[StructuredDocumentParser] RecognizeTextRequest captured \(extractedCount) words on page \(pageNumber) in \(String(format: "%.2f", elapsed))s", category: .ingestion)
+
                     return StructuredPageContent(
                         pageNumber: pageNumber,
                         elements: [.paragraph(text: fallbackText, pageNumber: pageNumber)],
                         rawText: fallbackText,
-                        qualityScore: 0.5, // Moderate quality since we have raw text but no structure
+                        qualityScore: qualityScore,
                         figureReferences: []
                     )
                 }

--- a/OpenIntelligence/Services/Document/Processing/StructuredDocumentParser.swift
+++ b/OpenIntelligence/Services/Document/Processing/StructuredDocumentParser.swift
@@ -652,7 +652,7 @@ actor StructuredDocumentParser {
                 let fallbackCG = fullResImageCG() ?? structureCG
                 let fallbackText = try await performTextRecognitionFallback(on: fallbackCG, customWords: customWords)
                 if !fallbackText.isEmpty {
-                    let extractedCount = fallbackText.split(separator: " ").count
+                    let extractedCount = fallbackText.components(separatedBy: .whitespacesAndNewlines).filter { !$0.isEmpty }.count
                     var qualityScore: Double = 0.5
 
                     // Gap 2 fix: use PDFKit native word count as ground truth denominator when provided.

--- a/OpenIntelligence/Services/Document/Processing/StructuredDocumentParser.swift
+++ b/OpenIntelligence/Services/Document/Processing/StructuredDocumentParser.swift
@@ -653,7 +653,7 @@ actor StructuredDocumentParser {
                 let fallbackText = try await performTextRecognitionFallback(on: fallbackCG, customWords: customWords)
                 if !fallbackText.isEmpty {
                     let extractedCount = fallbackText.split(separator: " ").count
-                    var qualityScore = 0.5
+                    var qualityScore: Double = 0.5
 
                     // Gap 2 fix: use PDFKit native word count as ground truth denominator when provided.
                     // This prevents artificial 100% scores when both OCR and extraction fail.

--- a/submit_script.sh
+++ b/submit_script.sh
@@ -1,1 +1,0 @@
-404: Not Found

--- a/submit_script.sh
+++ b/submit_script.sh
@@ -1,0 +1,1 @@
+404: Not Found


### PR DESCRIPTION
In StructuredDocumentParser.swift, the qualityScore for OCR fallback operations was hardcoded to 0.5. 

This change updates it to utilize the provided `nativeWordCount` (originating from PDFKit page attributes) as the ground truth denominator, preventing artificially inflated 100% extraction scores on documents with garbled or heavily degraded text layers where both OCR and spatial extraction mechanisms fail.

---
*PR created automatically by Jules for task [36703235622396954](https://jules.google.com/task/36703235622396954) started by @Gunnarguy*

## Summary by Sourcery

Adjust OCR fallback quality scoring to use PDFKit native word counts and update logging for extracted word counts.

Bug Fixes:
- Prevent inflated 100% extraction quality scores on pages where both OCR and text layer extraction fail by basing the fallback qualityScore on native word counts when available.

Chores:
- Add submit_script.sh placeholder file containing a 404 stub.