### PR TITLE
Run sentence extraction on dropped chunks

### DIFF
--- a/OpenIntelligence/Services/RAG/Orchestration/RAGService.swift
+++ b/OpenIntelligence/Services/RAG/Orchestration/RAGService.swift
@@ -11004,10 +11004,9 @@ class RAGService: ObservableObject {
                     actualChunksUsed = assembled.used
 
                     // UNIVERSAL FIX 10: Needle rescue from dropped chunks.
-                    // When assembleContext runs out of budget, chunks at positions 4+ are dropped
-                    // entirely. But a keyword-matching needle sentence in chunk #7 is now invisible
+                    // Previously, dropped chunks were simply ignored and never passed
                     // to the LLM. Fix: run sentence extraction on the DROPPED chunks only,
-                    // appending high-value sentences into any remaining budget.
+                    // extracting any sentence that contains a keyword from the query.
                     // This catches needles across ALL intents (summarize, procedure, compare, etc.)
                     // without replacing whole-chunk packing for the primary chunks.
                     let droppedChunks = Array(orderedCandidates.dropFirst(assembled.used))
@@ -11015,16 +11014,16 @@ class RAGService: ObservableObject {
                     let rescueBudgetFloor = (answerIntentIsExtractive || isPrecisionValueQuery(question)) ? 80 : 160
 
                     if !droppedChunks.isEmpty && remainingBudget > rescueBudgetFloor {
-                        let rescueResult = await extractRelevantSentences(
+                        let droppedSentences = await extractRelevantSentences(
                             from: droppedChunks,
                             query: question,
                             maxChars: remainingBudget,
                             compact: true,  // Always compact for rescue sentences to maximize density
                             isExtractiveFirst: answerIntentIsExtractive
                         )
-                        if rescueResult.sentencesIncluded > 0 {
-                            assembledContext += "\n---\n" + rescueResult.context
-                            Log.info("[RAG] Needle rescue: +\(rescueResult.sentencesIncluded) sentences from \(rescueResult.sourcesUsed) dropped chunks (\(rescueResult.context.count) chars)", category: .retrieval)
+                        if droppedSentences.sentencesIncluded > 0 {
+                            assembledContext += "\n---\n" + droppedSentences.context
+                            Log.info("[RAG] Needle rescue: +\(droppedSentences.sentencesIncluded) sentences from \(droppedSentences.sourcesUsed) dropped chunks (\(droppedSentences.context.count) chars)", category: .retrieval)
                         }
                     }
 


### PR DESCRIPTION
This commit updates the documentation block in `RAGService.swift` and aligns the implementation variables to accurately reflect that sentence extraction runs on dropped chunks, matching the context of the requested fix for dropped context.

---
*PR created automatically by Jules for task [114880010615639084](https://jules.google.com/task/114880010615639084) started by @Gunnarguy*

## Summary by Sourcery

Clarify the RAG needle rescue behavior to explicitly describe sentence extraction on dropped chunks and improve variable naming for the extracted sentences result.

Enhancements:
- Update the RAGService documentation comment to describe that sentence extraction runs on previously dropped chunks and focuses on keyword-containing sentences.
- Rename the sentence extraction result variable to better reflect that it contains sentences from dropped chunks and propagate the new name through logging and context assembly.