### PR TITLE
fix(ui): split ChatScreen body to fix CI type-checker timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 ### Fixed
-- **[Orchestration]** Split ChatScreen's ~430-line single `body` modifier chain into three separately type-checked layers (pure mechanical split, identical view tree). Fixes the Swift type-checker timeout ("unable to type-check this expression in reasonable time") that has failed GitHub Actions CI since 2026-07-09 and explains bot PR #65's false compile-error premise.
+- **[Orchestration]** Restructured the chat screen's view composition into separately compiled layers, resolving a Swift compiler timeout that could fail automated builds. No visual or behavioral change.
 
 ## 4.6 - 2026-07-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Fixed
+- **[Orchestration]** Split ChatScreen's ~430-line single `body` modifier chain into three separately type-checked layers (pure mechanical split, identical view tree). Fixes the Swift type-checker timeout ("unable to type-check this expression in reasonable time") that has failed GitHub Actions CI since 2026-07-09 and explains bot PR #65's false compile-error premise.
+
 ## 4.6 - 2026-07-14
 ### Fixed
 - **[Indexing]** Hardened FTS5 schema migrations: `ensureColumnExists` now takes a closed, compiler-owned `ColumnMigration` enum instead of raw table/column/definition strings, with identifier validation and proper identifier/PRAGMA quoting as defense in depth. Consolidates audited PRs #27 and #55; neither branch was merged directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Fixed
 - **[Orchestration]** Restructured the chat screen's view composition into separately compiled layers, resolving a Swift compiler timeout that could fail automated builds. No visual or behavioral change.
+- **[Orchestration]** Added an explicit initializer to the hardware X-Ray overlay so its sidebar-aware configuration constructs correctly across Swift compiler versions. No visual or behavioral change.
 
 ## 4.6 - 2026-07-14
 ### Fixed

--- a/OpenIntelligence/Features/Chat/Conversation/ChatScreen.swift
+++ b/OpenIntelligence/Features/Chat/Conversation/ChatScreen.swift
@@ -836,102 +836,102 @@ struct ChatScreen: View {
 
     var body: some View {
         chatPresentationLayer
-.onAppear {
-    let ragService = self.ragService
-    continuedQueryCoordinator.expirationHandler = { [weak ragService] in
-        ragService?.cancelActiveGeneration(resetSession: true)
-        Task { @MainActor in
-            self.currentQueryTask?.cancel()
-            self.currentQueryTask = nil
-            self.currentQuerySessionId = nil
-            self.isProcessing = false
-            self.stage = .idle
-            self.resetStreamingState()
-            self.generationStart = nil
+        .onAppear {
+            let ragService = self.ragService
+            continuedQueryCoordinator.expirationHandler = { [weak ragService] in
+                ragService?.cancelActiveGeneration(resetSession: true)
+                Task { @MainActor in
+                    self.currentQueryTask?.cancel()
+                    self.currentQueryTask = nil
+                    self.currentQuerySessionId = nil
+                    self.isProcessing = false
+                    self.stage = .idle
+                    self.resetStreamingState()
+                    self.generationStart = nil
+                }
+            }
+            continuedQueryCoordinator.handleScenePhaseChange(scenePhase, isProcessing: isProcessing)
+            // Seed screenshot demo FIRST before loading persisted history
+            seedScreenshotDemoIfNeeded()
+            entitlementStore.refreshTransientState()
+            isAppeared = true
+            if needsSuggestedQuestionsRefresh || dynamicSuggestedQuestions.isEmpty {
+                needsSuggestedQuestionsRefresh = false
+                refreshDynamicQuestions()
+            }
         }
-    }
-    continuedQueryCoordinator.handleScenePhaseChange(scenePhase, isProcessing: isProcessing)
-    // Seed screenshot demo FIRST before loading persisted history
-    seedScreenshotDemoIfNeeded()
-    entitlementStore.refreshTransientState()
-    isAppeared = true
-    if needsSuggestedQuestionsRefresh || dynamicSuggestedQuestions.isEmpty {
-        needsSuggestedQuestionsRefresh = false
-        refreshDynamicQuestions()
-    }
-}
-.onDisappear {
-    isAppeared = false
-}
-.onReceive(NotificationCenter.default.publisher(for: Notification.Name("ActiveModelRouteResolved"))) { notification in
-    guard let pathString = notification.userInfo?["executionPath"] as? String else { return }
-    switch pathString {
-    case "onDevice":
-        self.execution = .onDevice
-    case "privateCloudCompute":
-        self.execution = .privateCloudCompute
-    default:
-        break
-    }
-}
-// MARK: - NSUserActivity / Handoff
-.userActivity("com.openintelligence.chat") { activity in
-    activity.title = "Chat with Documents"
-    activity.isEligibleForSearch = true
-    activity.isEligibleForHandoff = true
-    #if os(iOS)
-    activity.isEligibleForPrediction = true
-    #endif
-    if let containerId = ragService.containerService.activeContainerId as UUID? {
-        activity.userInfo = ["containerId": containerId]
-    }
-    }
-    // MARK: - Translation Overlay
-    #if !targetEnvironment(macCatalyst)
-    .translationPresentation(isPresented: $showTranslation, text: translationText)
-    #endif
-    // MARK: - WritingTools Result Sheet
-    .sheet(isPresented: $showWritingToolsResult) {
-    WritingToolsResultSheet(
-        title: writingToolsTitle,
-        result: writingToolsResult,
-        onCopy: {
-            #if canImport(UIKit)
-            UIPasteboard.general.string = writingToolsResult
+        .onDisappear {
+            isAppeared = false
+        }
+        .onReceive(NotificationCenter.default.publisher(for: Notification.Name("ActiveModelRouteResolved"))) { notification in
+            guard let pathString = notification.userInfo?["executionPath"] as? String else { return }
+            switch pathString {
+            case "onDevice":
+                self.execution = .onDevice
+            case "privateCloudCompute":
+                self.execution = .privateCloudCompute
+            default:
+                break
+            }
+        }
+        // MARK: - NSUserActivity / Handoff
+        .userActivity("com.openintelligence.chat") { activity in
+            activity.title = "Chat with Documents"
+            activity.isEligibleForSearch = true
+            activity.isEligibleForHandoff = true
+            #if os(iOS)
+            activity.isEligibleForPrediction = true
             #endif
-            DSHaptics.success()
-            toastManager.show(
-                ToastItem(title: "Copied to clipboard", icon: "doc.on.doc", tint: .green),
-                duration: 1.5
-            )
-        },
-        onInsertAsReply: {
-            showWritingToolsResult = false
-            let writingMessage = ChatMessage(
-                role: .assistant,
-                content: "**\(writingToolsTitle):**\n\n\(writingToolsResult)"
-            )
-            messages.append(writingMessage)
-        },
-        onFeedback: { isPositive in
-            // Log quality signal to pipeline observability.
-            // When LanguageModelSession.logFeedbackAttachment is wired through the
-            // service layer, re-route here for official Apple FM telemetry.
-            let signal = isPositive ? "positive" : "negative"
-            Log.info("[AIHub] User feedback '\(signal)' for \(writingToolsTitle)", category: .pipeline)
-            DSHaptics.selection()
-            toastManager.show(
-                ToastItem(
-                    title: isPositive ? "Thanks for the feedback!" : "Got it — we'll improve",
-                    icon: isPositive ? "hand.thumbsup.fill" : "hand.thumbsdown.fill",
-                    tint: isPositive ? .green : .orange
-                ),
-                duration: 2.0
-            )
+            if let containerId = ragService.containerService.activeContainerId as UUID? {
+                activity.userInfo = ["containerId": containerId]
+            }
         }
-    )
-    .presentationDetents([.medium, .large])
-}
+        // MARK: - Translation Overlay
+        #if !targetEnvironment(macCatalyst)
+            .translationPresentation(isPresented: $showTranslation, text: translationText)
+        #endif
+        // MARK: - WritingTools Result Sheet
+        .sheet(isPresented: $showWritingToolsResult) {
+            WritingToolsResultSheet(
+                title: writingToolsTitle,
+                result: writingToolsResult,
+                onCopy: {
+                    #if canImport(UIKit)
+                    UIPasteboard.general.string = writingToolsResult
+                    #endif
+                    DSHaptics.success()
+                    toastManager.show(
+                        ToastItem(title: "Copied to clipboard", icon: "doc.on.doc", tint: .green),
+                        duration: 1.5
+                    )
+                },
+                onInsertAsReply: {
+                    showWritingToolsResult = false
+                    let writingMessage = ChatMessage(
+                        role: .assistant,
+                        content: "**\(writingToolsTitle):**\n\n\(writingToolsResult)"
+                    )
+                    messages.append(writingMessage)
+                },
+                onFeedback: { isPositive in
+                    // Log quality signal to pipeline observability.
+                    // When LanguageModelSession.logFeedbackAttachment is wired through the
+                    // service layer, re-route here for official Apple FM telemetry.
+                    let signal = isPositive ? "positive" : "negative"
+                    Log.info("[AIHub] User feedback '\(signal)' for \(writingToolsTitle)", category: .pipeline)
+                    DSHaptics.selection()
+                    toastManager.show(
+                        ToastItem(
+                            title: isPositive ? "Thanks for the feedback!" : "Got it — we'll improve",
+                            icon: isPositive ? "hand.thumbsup.fill" : "hand.thumbsdown.fill",
+                            tint: isPositive ? .green : .orange
+                        ),
+                        duration: 2.0
+                    )
+                }
+            )
+            .presentationDetents([.medium, .large])
+        }
     }
 
     private var streamingTokensApprox: Int {

--- a/OpenIntelligence/Features/Chat/Conversation/ChatScreen.swift
+++ b/OpenIntelligence/Features/Chat/Conversation/ChatScreen.swift
@@ -490,7 +490,12 @@ struct ChatScreen: View {
         )
     }
 
-    var body: some View {
+    // `body` is split into three layers (chatLifecycleLayer → chatPresentationLayer
+    // → body) because the original single ~430-line modifier chain exceeded the
+    // Swift type-checker budget on slower CI hardware ("unable to type-check this
+    // expression in reasonable time"). Pure mechanical split: modifier order and
+    // the resulting view tree are unchanged.
+    private var chatLifecycleLayer: some View {
         ZStack(alignment: .top) {
             mainContentArea
 
@@ -655,6 +660,10 @@ struct ChatScreen: View {
         .onReceive(ragService.$pendingCloudConsent) { record in
             activeCloudConsent = record
         }
+    }
+
+    private var chatPresentationLayer: some View {
+        chatLifecycleLayer
         .toolbar {
             #if os(iOS)
                 ToolbarItem(placement: .topBarLeading) {
@@ -823,6 +832,10 @@ struct ChatScreen: View {
         } message: {
             Text("I'm sorry that answer wasn't helpful. Please send me your feedback so I can improve OpenIntelligence!")
         }
+    }
+
+    var body: some View {
+        chatPresentationLayer
 .onAppear {
     let ragService = self.ragService
     continuedQueryCoordinator.expirationHandler = { [weak ragService] in

--- a/OpenIntelligence/Features/Telemetry/Dashboard/MotherboardHUDView.swift
+++ b/OpenIntelligence/Features/Telemetry/Dashboard/MotherboardHUDView.swift
@@ -295,6 +295,15 @@ struct HardwareXRayOverlay: View {
     var showDeviceInfo: Bool = false
     var showSidebar: Bool = false
 
+    /// Explicit initializer. The synthesized memberwise init inherits `private`
+    /// from the private stored properties above, so cross-file callers (e.g.
+    /// ChatScreen's `showSidebar:` call) cannot see it under older Swift
+    /// compilers — CI failed on exactly that. Keep this internal and defaulted.
+    init(showDeviceInfo: Bool = false, showSidebar: Bool = false) {
+        self.showDeviceInfo = showDeviceInfo
+        self.showSidebar = showSidebar
+    }
+
     /// Combined intensity from all active components
     private var totalIntensity: Double {
         max(telemetry.cpuIntensity, telemetry.gpuIntensity, telemetry.aneIntensity)


### PR DESCRIPTION
Fixes the Swift type-checker timeout at ChatScreen.swift:564 that has failed GitHub Actions CI since 2026-07-09, including on main itself (byte-identical error on main's July 9 run — predates the v4.6 consolidation).

Pure mechanical split of the ~430-line `body` modifier chain into three separately type-checked layers (`chatLifecycleLayer` → `chatPresentationLayer` → `body`). Modifier order and the resulting view tree are unchanged; no behavior change.

Also closes the loop on bot PR #65's false 'ChatScreen compile error' premise — the bot was hitting this same environment-dependent timeout.

Verification: this PR's own Build check is the test — it fails without this change (see any run since July 9) and should pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Split ChatScreen’s large SwiftUI view hierarchy into layered properties to resolve CI type-checker timeouts without changing runtime behavior.

Enhancements:
- Refactor ChatScreen’s single, deeply nested `body` modifier chain into separate lifecycle and presentation layers while preserving the resulting view structure.

Documentation:
- Document the ChatScreen refactor and CI type-checker timeout fix in the unreleased section of the changelog.